### PR TITLE
feat: added the ability to overwrite select APIs in a broken schema

### DIFF
--- a/crates/mcp/src/server/schemas.rs
+++ b/crates/mcp/src/server/schemas.rs
@@ -172,6 +172,53 @@ pub struct CatalogImportOpenApiRequest {
     pub enabled: Option<bool>,
 }
 
+/// Request payload for applying deterministic command replacements to an existing catalog.
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct CatalogApplyPatchRequest {
+    /// Existing catalog title to patch.
+    #[schemars(description = "Existing catalog title to patch.")]
+    pub catalog_id: String,
+    /// Ordered patch operations.
+    #[schemars(description = "Ordered patch operations to apply.")]
+    pub operations: Vec<CatalogPatchOperationInput>,
+    /// Fail when a target command is missing. Defaults to true.
+    #[schemars(description = "Fail when a target command is missing. Defaults to true.")]
+    pub fail_on_missing: Option<bool>,
+    /// Fail when matching is ambiguous. Defaults to true.
+    #[schemars(description = "Fail when command matching is ambiguous. Defaults to true.")]
+    pub fail_on_ambiguous: Option<bool>,
+    /// Persist by replacing the existing catalog entry. Defaults to true.
+    #[schemars(description = "Persist patched catalog by replacing the existing catalog entry. Defaults to true.")]
+    pub overwrite: Option<bool>,
+}
+
+/// Single command replacement operation in a patch request.
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct CatalogPatchOperationInput {
+    /// Optional operation identifier for diagnostics.
+    #[schemars(description = "Optional operation identifier for diagnostics.")]
+    pub operation_id: Option<String>,
+    /// Strict target command match key.
+    #[schemars(description = "Strict command identity key used to select the replacement target.")]
+    pub match_command: CatalogCommandMatchKeyInput,
+    /// Full replacement command specification payload.
+    #[schemars(description = "Full replacement command specification payload.")]
+    pub replacement_command: Value,
+}
+
+/// Match key for targeting an existing command.
+#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CatalogCommandMatchKeyInput {
+    /// Command group (for example `apps`).
+    pub group: String,
+    /// Command name (for example `apps:list`).
+    pub name: String,
+    /// HTTP method (for example `GET`).
+    pub http_method: String,
+    /// HTTP path (for example `/v1/apps`).
+    pub http_path: String,
+}
+
 /// Request payload for enabling or disabling an existing catalog.
 #[derive(JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CatalogSetEnabledRequest {

--- a/crates/registry-gen/src/io.rs
+++ b/crates/registry-gen/src/io.rs
@@ -112,6 +112,14 @@ pub fn generate_manifest(mut input: ManifestInput) -> Result<RegistryManifest> {
     })
 }
 
+/// Builds provider contracts for an already-materialized command list.
+///
+/// This helper is used by catalog mutation paths that replace command
+/// specifications without re-generating the full catalog from OpenAPI.
+pub fn build_provider_contracts_for_commands(commands: &[CommandSpec]) -> IndexMap<String, ProviderContract> {
+    build_provider_contracts(commands)
+}
+
 /// Writes the command manifest to a file.
 ///
 /// This function reads OpenAPI documents from the input paths, generates

--- a/crates/registry/src/catalog_patch.rs
+++ b/crates/registry/src/catalog_patch.rs
@@ -1,0 +1,422 @@
+//! Catalog patch application service.
+//!
+//! This module provides deterministic command-level patching for an existing
+//! catalog manifest. Patch operations replace full command specifications by a
+//! strict match key and then persist the patched catalog through the normal
+//! registry insertion path.
+
+use crate::CommandRegistry;
+use crate::catalog_persistence::{CatalogPersistErrorKind, replace_catalog_and_persist};
+use oatty_registry_gen::io::build_provider_contracts_for_commands;
+use oatty_types::{CommandSpec, manifest::RegistryCatalog};
+use oatty_util::sort_and_dedup_commands;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Request to apply deterministic command replacements to an existing catalog.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CatalogPatchApplyRequest {
+    /// Existing catalog title to patch.
+    pub target_catalog_title: String,
+    /// Ordered replacement operations applied from first to last.
+    pub operations: Vec<CatalogPatchOperation>,
+    /// Fail when an operation does not match an existing command.
+    pub fail_on_missing: bool,
+    /// Fail when an operation matches multiple commands.
+    pub fail_on_ambiguous: bool,
+    /// Persist the patched catalog by replacing the existing catalog entry.
+    pub overwrite_existing_catalog: bool,
+}
+
+impl Default for CatalogPatchApplyRequest {
+    fn default() -> Self {
+        Self {
+            target_catalog_title: String::new(),
+            operations: Vec::new(),
+            fail_on_missing: true,
+            fail_on_ambiguous: true,
+            overwrite_existing_catalog: true,
+        }
+    }
+}
+
+impl CatalogPatchApplyRequest {
+    /// Creates a patch request with default policy values.
+    pub fn new(target_catalog_title: String, operations: Vec<CatalogPatchOperation>) -> Self {
+        Self {
+            target_catalog_title,
+            operations,
+            ..Self::default()
+        }
+    }
+
+    /// Applies optional policy overrides while preserving defaults when omitted.
+    pub fn with_policy_overrides(
+        mut self,
+        fail_on_missing: Option<bool>,
+        fail_on_ambiguous: Option<bool>,
+        overwrite_existing_catalog: Option<bool>,
+    ) -> Self {
+        if let Some(fail_on_missing) = fail_on_missing {
+            self.fail_on_missing = fail_on_missing;
+        }
+        if let Some(fail_on_ambiguous) = fail_on_ambiguous {
+            self.fail_on_ambiguous = fail_on_ambiguous;
+        }
+        if let Some(overwrite_existing_catalog) = overwrite_existing_catalog {
+            self.overwrite_existing_catalog = overwrite_existing_catalog;
+        }
+        self
+    }
+}
+
+/// Successful patch application metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CatalogPatchApplyResult {
+    /// Catalog identifier that was patched.
+    pub catalog_id: String,
+    /// Number of requested operations.
+    pub requested_operation_count: usize,
+    /// Number of operations that were applied.
+    pub applied_operation_count: usize,
+    /// Number of commands in the patched manifest.
+    pub final_command_count: usize,
+    /// Number of provider contracts in the patched manifest.
+    pub final_provider_contract_count: usize,
+    /// Per-operation outcomes.
+    pub operation_results: Vec<CatalogPatchOperationResult>,
+    /// Patched catalog record when persisted.
+    pub catalog: Option<RegistryCatalog>,
+}
+
+/// Single patch operation for replacing one command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CatalogPatchOperation {
+    /// Optional operation identifier for diagnostics.
+    pub operation_id: Option<String>,
+    /// Strict matching key used to find the target command.
+    pub match_command: CatalogCommandMatchKey,
+    /// Full replacement command specification.
+    pub replacement_command: CommandSpec,
+}
+
+/// Stable key for matching target commands in a catalog manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CatalogCommandMatchKey {
+    /// Command group (for example, `projects`).
+    pub group: String,
+    /// Command name (for example, `projects:list`).
+    pub name: String,
+    /// HTTP method (for example, `GET`).
+    pub http_method: String,
+    /// HTTP path (for example, `/v1/projects`).
+    pub http_path: String,
+}
+
+/// Per-operation patch result.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CatalogPatchOperationResult {
+    /// Optional operation identifier.
+    pub operation_id: Option<String>,
+    /// Operation status.
+    pub status: CatalogPatchOperationStatus,
+    /// Number of commands matched by the operation key.
+    pub matched_count: usize,
+    /// Canonical identifier of the replaced command after patching.
+    pub replaced_canonical_id: Option<String>,
+    /// Optional detail message.
+    pub message: Option<String>,
+}
+
+/// Patch operation status classification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogPatchOperationStatus {
+    /// Operation replaced a command.
+    Applied,
+    /// Operation was skipped due to non-fatal policy.
+    Skipped,
+}
+
+/// Errors emitted while applying a catalog patch.
+#[derive(Debug, Error)]
+pub enum CatalogPatchApplyError {
+    /// Target catalog was not found.
+    #[error("catalog '{0}' not found")]
+    CatalogNotFound(String),
+    /// Target catalog has no in-memory manifest payload.
+    #[error("catalog '{0}' has no manifest content")]
+    MissingManifest(String),
+    /// An operation did not match any command.
+    #[error("operation {operation_index} target not found")]
+    TargetNotFound { operation_index: usize },
+    /// An operation matched multiple commands.
+    #[error("operation {operation_index} target is ambiguous (matched {matched_count})")]
+    TargetAmbiguous { operation_index: usize, matched_count: usize },
+    /// The patch request requires overwrite persistence.
+    #[error("overwrite_existing_catalog must be true to persist a patch")]
+    OverwriteRequired,
+    /// Registry replacement failed.
+    #[error("failed to replace catalog '{catalog_id}': {message}")]
+    ReplaceFailed { catalog_id: String, message: String },
+    /// Registry insertion failed.
+    #[error("failed to insert patched catalog '{catalog_id}': {message}")]
+    InsertFailed { catalog_id: String, message: String },
+    /// Registry config persistence failed.
+    #[error("failed to save patched catalog '{catalog_id}': {message}")]
+    SaveFailed { catalog_id: String, message: String },
+    /// Patched catalog record could not be reloaded after save.
+    #[error("patched catalog '{0}' is unavailable after save")]
+    PersistedCatalogUnavailable(String),
+}
+
+/// Applies deterministic patch operations to an existing catalog manifest.
+pub fn apply_catalog_patch(
+    registry: &mut CommandRegistry,
+    request: CatalogPatchApplyRequest,
+) -> Result<CatalogPatchApplyResult, CatalogPatchApplyError> {
+    if !request.overwrite_existing_catalog {
+        return Err(CatalogPatchApplyError::OverwriteRequired);
+    }
+
+    let existing_catalog = get_catalog_by_title(registry, &request.target_catalog_title)
+        .cloned()
+        .ok_or_else(|| CatalogPatchApplyError::CatalogNotFound(request.target_catalog_title.clone()))?;
+    let mut patched_catalog = existing_catalog.clone();
+    let manifest = patched_catalog
+        .manifest
+        .as_mut()
+        .ok_or_else(|| CatalogPatchApplyError::MissingManifest(request.target_catalog_title.clone()))?;
+
+    let mut operation_results = Vec::with_capacity(request.operations.len());
+    let mut applied_operation_count = 0usize;
+    for (operation_index, operation) in request.operations.iter().enumerate() {
+        let matching_indexes = find_matching_command_indexes(&manifest.commands, &operation.match_command);
+        if matching_indexes.is_empty() {
+            if request.fail_on_missing {
+                return Err(CatalogPatchApplyError::TargetNotFound { operation_index });
+            }
+            operation_results.push(build_skipped_result(
+                operation.operation_id.clone(),
+                0,
+                "target command not found".to_string(),
+            ));
+            continue;
+        }
+        if matching_indexes.len() > 1 {
+            if request.fail_on_ambiguous {
+                return Err(CatalogPatchApplyError::TargetAmbiguous {
+                    operation_index,
+                    matched_count: matching_indexes.len(),
+                });
+            }
+            operation_results.push(build_skipped_result(
+                operation.operation_id.clone(),
+                matching_indexes.len(),
+                "target command match is ambiguous".to_string(),
+            ));
+            continue;
+        }
+
+        let target_index = matching_indexes[0];
+        manifest.commands[target_index] = operation.replacement_command.clone();
+        applied_operation_count += 1;
+        operation_results.push(CatalogPatchOperationResult {
+            operation_id: operation.operation_id.clone(),
+            status: CatalogPatchOperationStatus::Applied,
+            matched_count: 1,
+            replaced_canonical_id: Some(manifest.commands[target_index].canonical_id()),
+            message: None,
+        });
+    }
+
+    sort_and_dedup_commands(&mut manifest.commands);
+    manifest.provider_contracts = build_provider_contracts_for_commands(&manifest.commands);
+
+    replace_catalog_and_persist(registry, &request.target_catalog_title, patched_catalog.clone())
+        .map_err(|error| map_catalog_persist_error_to_patch_error(&request.target_catalog_title, error.kind, error.message))?;
+    let persisted_catalog = get_catalog_by_title(registry, &request.target_catalog_title)
+        .cloned()
+        .ok_or_else(|| CatalogPatchApplyError::PersistedCatalogUnavailable(request.target_catalog_title.clone()))?;
+
+    Ok(CatalogPatchApplyResult {
+        catalog_id: request.target_catalog_title,
+        requested_operation_count: request.operations.len(),
+        applied_operation_count,
+        final_command_count: persisted_catalog
+            .manifest
+            .as_ref()
+            .map(|manifest| manifest.commands.len())
+            .unwrap_or(0),
+        final_provider_contract_count: persisted_catalog
+            .manifest
+            .as_ref()
+            .map(|manifest| manifest.provider_contracts.len())
+            .unwrap_or(0),
+        operation_results,
+        catalog: Some(persisted_catalog),
+    })
+}
+
+fn build_skipped_result(operation_id: Option<String>, matched_count: usize, message: String) -> CatalogPatchOperationResult {
+    CatalogPatchOperationResult {
+        operation_id,
+        status: CatalogPatchOperationStatus::Skipped,
+        matched_count,
+        replaced_canonical_id: None,
+        message: Some(message),
+    }
+}
+
+fn find_matching_command_indexes(commands: &[CommandSpec], match_key: &CatalogCommandMatchKey) -> Vec<usize> {
+    commands
+        .iter()
+        .enumerate()
+        .filter_map(|(index, command)| {
+            let http = command.http()?;
+            let method_matches = http.method.eq_ignore_ascii_case(match_key.http_method.trim());
+            let path_matches = http.path.trim() == match_key.http_path.trim();
+            if command.group == match_key.group && command.name == match_key.name && method_matches && path_matches {
+                return Some(index);
+            }
+            None
+        })
+        .collect()
+}
+
+fn map_catalog_persist_error_to_patch_error(catalog_id: &str, kind: CatalogPersistErrorKind, message: String) -> CatalogPatchApplyError {
+    match kind {
+        CatalogPersistErrorKind::Replace => CatalogPatchApplyError::ReplaceFailed {
+            catalog_id: catalog_id.to_string(),
+            message,
+        },
+        CatalogPersistErrorKind::Insert => CatalogPatchApplyError::InsertFailed {
+            catalog_id: catalog_id.to_string(),
+            message,
+        },
+        CatalogPersistErrorKind::Save => CatalogPatchApplyError::SaveFailed {
+            catalog_id: catalog_id.to_string(),
+            message,
+        },
+    }
+}
+
+fn get_catalog_by_title<'catalog>(registry: &'catalog CommandRegistry, catalog_title: &str) -> Option<&'catalog RegistryCatalog> {
+    registry
+        .config
+        .catalogs
+        .as_ref()
+        .and_then(|catalogs| catalogs.iter().find(|catalog| catalog.title == catalog_title))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RegistryConfig;
+    use indexmap::IndexMap;
+    use oatty_types::{command::HttpCommandSpec, manifest::RegistryManifest};
+    use std::{fs, time};
+
+    fn build_command(group: &str, name: &str, method: &str, path: &str) -> CommandSpec {
+        CommandSpec::new_http(
+            group.to_string(),
+            name.to_string(),
+            "summary".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new(method, path, None, None),
+            0,
+        )
+    }
+
+    fn sample_registry() -> CommandRegistry {
+        let command = build_command("apps", "apps:list", "GET", "/apps");
+        let manifest = RegistryManifest {
+            commands: vec![command],
+            provider_contracts: IndexMap::new(),
+            vendor: "apps".to_string(),
+        };
+        let manifest_bytes: Vec<u8> = manifest.clone().try_into().expect("manifest serializes");
+        let manifest_path = unique_manifest_path();
+        fs::write(&manifest_path, manifest_bytes).expect("manifest file");
+        let catalog = RegistryCatalog {
+            title: "Apps".to_string(),
+            description: String::new(),
+            vendor: Some("apps".to_string()),
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+            import_source: None,
+            import_source_type: None,
+            headers: Default::default(),
+            base_urls: vec!["https://example.com".to_string()],
+            base_url_index: 0,
+            manifest: Some(manifest),
+            is_enabled: true,
+        };
+        CommandRegistry::from_registry_config(RegistryConfig {
+            catalogs: Some(vec![catalog]),
+        })
+        .expect("registry")
+    }
+
+    fn unique_manifest_path() -> std::path::PathBuf {
+        let nanos = time::SystemTime::now().duration_since(time::UNIX_EPOCH).expect("time").as_nanos();
+        std::env::temp_dir().join(format!("oatty-catalog-patch-{nanos}.bin"))
+    }
+
+    #[test]
+    fn apply_catalog_patch_replaces_matching_command() {
+        let mut registry = sample_registry();
+        let replacement = build_command("apps", "apps:list", "GET", "/v2/apps");
+        let result = apply_catalog_patch(
+            &mut registry,
+            CatalogPatchApplyRequest {
+                target_catalog_title: "Apps".to_string(),
+                operations: vec![CatalogPatchOperation {
+                    operation_id: Some("replace-apps-list".to_string()),
+                    match_command: CatalogCommandMatchKey {
+                        group: "apps".to_string(),
+                        name: "apps:list".to_string(),
+                        http_method: "GET".to_string(),
+                        http_path: "/apps".to_string(),
+                    },
+                    replacement_command: replacement,
+                }],
+                fail_on_missing: true,
+                fail_on_ambiguous: true,
+                overwrite_existing_catalog: true,
+            },
+        )
+        .expect("patch succeeds");
+
+        assert_eq!(result.applied_operation_count, 1);
+        let command = registry.find_by_group_and_cmd_ref("apps", "apps:list").expect("patched command");
+        assert_eq!(command.http().expect("http command").path, "/v2/apps");
+    }
+
+    #[test]
+    fn apply_catalog_patch_fails_when_target_missing() {
+        let mut registry = sample_registry();
+        let error = apply_catalog_patch(
+            &mut registry,
+            CatalogPatchApplyRequest {
+                target_catalog_title: "Apps".to_string(),
+                operations: vec![CatalogPatchOperation {
+                    operation_id: None,
+                    match_command: CatalogCommandMatchKey {
+                        group: "apps".to_string(),
+                        name: "apps:get".to_string(),
+                        http_method: "GET".to_string(),
+                        http_path: "/apps/{id}".to_string(),
+                    },
+                    replacement_command: build_command("apps", "apps:get", "GET", "/apps/{id}"),
+                }],
+                fail_on_missing: true,
+                fail_on_ambiguous: true,
+                overwrite_existing_catalog: true,
+            },
+        )
+        .expect_err("missing should fail");
+
+        assert!(matches!(error, CatalogPatchApplyError::TargetNotFound { .. }));
+    }
+}

--- a/crates/registry/src/catalog_persistence.rs
+++ b/crates/registry/src/catalog_persistence.rs
@@ -1,0 +1,249 @@
+//! Shared catalog persistence helpers.
+//!
+//! This module centralizes catalog replace/insert + config persistence behavior
+//! so import and patch flows reuse one implementation path.
+
+use crate::CommandRegistry;
+use anyhow::{Result, anyhow};
+use heck::ToSnakeCase;
+use oatty_types::manifest::RegistryCatalog;
+use postcard::to_stdvec;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Error category emitted by catalog persistence operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogPersistErrorKind {
+    /// Existing catalog removal failed during overwrite.
+    Replace,
+    /// Inserting a catalog into registry state failed.
+    Insert,
+    /// Saving registry config to disk failed.
+    Save,
+}
+
+/// Structured catalog persistence error.
+#[derive(Debug)]
+pub(crate) struct CatalogPersistError {
+    /// Failure category.
+    pub kind: CatalogPersistErrorKind,
+    /// Human-readable failure message.
+    pub message: String,
+}
+
+/// Inserts a catalog and persists registry config.
+pub(crate) fn insert_catalog_and_persist(registry: &mut CommandRegistry, catalog: RegistryCatalog) -> Result<(), CatalogPersistError> {
+    registry.insert_catalog(catalog).map_err(|error| CatalogPersistError {
+        kind: CatalogPersistErrorKind::Insert,
+        message: error.to_string(),
+    })?;
+    let inserted_catalog_title = registry
+        .config
+        .catalogs
+        .as_ref()
+        .and_then(|catalogs| catalogs.last())
+        .map(|catalog| catalog.title.clone());
+    persist_catalog_manifest_by_title(registry, inserted_catalog_title.as_deref()).map_err(|error| CatalogPersistError {
+        kind: CatalogPersistErrorKind::Save,
+        message: error.to_string(),
+    })?;
+    registry.config.save().map_err(|error| CatalogPersistError {
+        kind: CatalogPersistErrorKind::Save,
+        message: error.to_string(),
+    })?;
+    Ok(())
+}
+
+/// Replaces an existing catalog with a new catalog and persists registry config.
+pub(crate) fn replace_catalog_and_persist(
+    registry: &mut CommandRegistry,
+    catalog_id: &str,
+    replacement_catalog: RegistryCatalog,
+) -> Result<(), CatalogPersistError> {
+    let removed_catalog = remove_catalog_for_overwrite(registry, catalog_id).map_err(|error| CatalogPersistError {
+        kind: CatalogPersistErrorKind::Replace,
+        message: error.to_string(),
+    })?;
+    let manifest_backup = backup_manifest_bytes(&removed_catalog.manifest_path);
+
+    if let Err(error) = registry.insert_catalog(replacement_catalog) {
+        let _ = restore_catalog_after_failed_replace(registry, removed_catalog);
+        return Err(CatalogPersistError {
+            kind: CatalogPersistErrorKind::Insert,
+            message: error.to_string(),
+        });
+    }
+    if let Err(error) = persist_catalog_manifest_by_title(registry, Some(catalog_id)) {
+        restore_manifest_backup(&removed_catalog.manifest_path, manifest_backup.as_deref());
+        let _ = remove_catalog_entry_without_manifest_delete(registry, catalog_id);
+        let _ = restore_catalog_after_failed_replace(registry, removed_catalog);
+        return Err(CatalogPersistError {
+            kind: CatalogPersistErrorKind::Save,
+            message: error.to_string(),
+        });
+    }
+
+    if let Err(error) = registry.config.save() {
+        restore_manifest_backup(&removed_catalog.manifest_path, manifest_backup.as_deref());
+        let _ = remove_catalog_entry_without_manifest_delete(registry, catalog_id);
+        let _ = restore_catalog_after_failed_replace(registry, removed_catalog);
+        return Err(CatalogPersistError {
+            kind: CatalogPersistErrorKind::Save,
+            message: error.to_string(),
+        });
+    }
+
+    cleanup_replaced_manifest_file_if_orphan(registry, catalog_id, &removed_catalog.manifest_path);
+    Ok(())
+}
+
+fn remove_catalog_for_overwrite(registry: &mut CommandRegistry, catalog_id: &str) -> Result<RegistryCatalog> {
+    let removed_catalog_snapshot = registry
+        .config
+        .catalogs
+        .as_ref()
+        .and_then(|catalogs| catalogs.iter().find(|catalog| catalog.title == catalog_id))
+        .cloned()
+        .ok_or_else(|| anyhow!("catalog not found"))?;
+
+    registry.disable_catalog(catalog_id).map_err(|error| anyhow!(error.to_string()))?;
+
+    let Some(catalogs) = registry.config.catalogs.as_mut() else {
+        return Err(anyhow!("no catalogs configured"));
+    };
+    let Some(index) = catalogs.iter().position(|catalog| catalog.title == catalog_id) else {
+        return Err(anyhow!("catalog not found"));
+    };
+    catalogs.remove(index);
+    reindex_catalog_identifiers(registry);
+    Ok(removed_catalog_snapshot)
+}
+
+fn restore_catalog_after_failed_replace(registry: &mut CommandRegistry, removed_catalog: RegistryCatalog) -> Result<()> {
+    registry
+        .insert_catalog(removed_catalog)
+        .map_err(|error| anyhow!("failed to restore replaced catalog: {error}"))
+}
+
+fn remove_catalog_entry_without_manifest_delete(registry: &mut CommandRegistry, catalog_id: &str) -> Result<()> {
+    registry.disable_catalog(catalog_id).map_err(|error| anyhow!(error.to_string()))?;
+    let Some(catalogs) = registry.config.catalogs.as_mut() else {
+        return Err(anyhow!("no catalogs configured"));
+    };
+    let Some(index) = catalogs.iter().position(|catalog| catalog.title == catalog_id) else {
+        return Err(anyhow!("catalog not found"));
+    };
+    catalogs.remove(index);
+    reindex_catalog_identifiers(registry);
+    Ok(())
+}
+
+fn backup_manifest_bytes(manifest_path: &str) -> Option<Vec<u8>> {
+    let path = Path::new(manifest_path);
+    if !path.exists() {
+        return None;
+    }
+    std::fs::read(path).ok()
+}
+
+fn restore_manifest_backup(manifest_path: &str, backup: Option<&[u8]>) {
+    let Some(backup) = backup else {
+        return;
+    };
+    let _ = std::fs::write(manifest_path, backup);
+}
+
+fn cleanup_replaced_manifest_file_if_orphan(registry: &CommandRegistry, catalog_id: &str, old_manifest_path: &str) {
+    let current_manifest_path = registry
+        .config
+        .catalogs
+        .as_ref()
+        .and_then(|catalogs| catalogs.iter().find(|catalog| catalog.title == catalog_id))
+        .map(|catalog| catalog.manifest_path.as_str());
+    if current_manifest_path.is_some_and(|current_path| current_path == old_manifest_path) {
+        return;
+    }
+    let old_path = Path::new(old_manifest_path);
+    if old_path.exists() {
+        let _ = std::fs::remove_file(old_path);
+    }
+}
+
+fn persist_catalog_manifest_by_title(registry: &mut CommandRegistry, catalog_title: Option<&str>) -> Result<()> {
+    let Some(catalog_title) = catalog_title else {
+        return Ok(());
+    };
+    let Some(catalogs) = registry.config.catalogs.as_mut() else {
+        return Ok(());
+    };
+    let Some(catalog) = catalogs.iter_mut().find(|catalog| catalog.title == catalog_title) else {
+        return Ok(());
+    };
+    persist_catalog_manifest(catalog)
+}
+
+fn persist_catalog_manifest(catalog: &mut RegistryCatalog) -> Result<()> {
+    let Some(manifest) = catalog.manifest.as_ref() else {
+        return Ok(());
+    };
+    let manifest_bytes = to_stdvec(manifest).map_err(|error| anyhow!("failed to serialize manifest: {error}"))?;
+    let mut manifest_path = catalog.manifest_path.clone();
+    if manifest_path.trim().is_empty() {
+        let catalogs_path = crate::default_catalogs_path();
+        std::fs::create_dir_all(&catalogs_path)?;
+        manifest_path = catalogs_path
+            .join(format!("{}.bin", catalog.title.to_snake_case()))
+            .to_string_lossy()
+            .to_string();
+    } else if let Some(parent) = Path::new(&manifest_path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_manifest_bytes_atomically(&manifest_path, &manifest_bytes)?;
+    catalog.manifest_path = manifest_path;
+    Ok(())
+}
+
+fn write_manifest_bytes_atomically(manifest_path: &str, manifest_bytes: &[u8]) -> Result<()> {
+    let manifest_path_ref = Path::new(manifest_path);
+    let parent_directory = manifest_path_ref.parent().unwrap_or_else(|| Path::new("."));
+    let temp_manifest_path = build_temp_manifest_path(parent_directory);
+
+    let mut temp_file = File::create(&temp_manifest_path)?;
+    temp_file.write_all(manifest_bytes)?;
+    temp_file.sync_all()?;
+    drop(temp_file);
+
+    std::fs::rename(&temp_manifest_path, manifest_path_ref)?;
+    Ok(())
+}
+
+fn build_temp_manifest_path(parent_directory: &Path) -> std::path::PathBuf {
+    let process_identifier = std::process::id();
+    let timestamp_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    parent_directory.join(format!(".catalog-manifest-{process_identifier}-{timestamp_nanos}.tmp"))
+}
+
+fn reindex_catalog_identifiers(registry: &mut CommandRegistry) {
+    let mut canonical_id_to_catalog_index = HashMap::<String, usize>::new();
+    if let Some(catalogs) = registry.config.catalogs.as_mut() {
+        for (catalog_index, catalog) in catalogs.iter_mut().enumerate() {
+            if let Some(manifest) = catalog.manifest.as_mut() {
+                for command in &mut manifest.commands {
+                    command.catalog_identifier = catalog_index;
+                    canonical_id_to_catalog_index.insert(command.canonical_id(), catalog_index);
+                }
+            }
+        }
+    }
+    for command in &mut registry.commands {
+        if let Some(index) = canonical_id_to_catalog_index.get(&command.canonical_id()) {
+            command.catalog_identifier = *index;
+        }
+    }
+}

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides the core data structures and functionality for loading,
 //! organizing, and generating CLI commands from Oatty API schemas.
 
+pub mod catalog_patch;
+mod catalog_persistence;
 pub mod clap_builder;
 pub mod config;
 pub mod models;
@@ -10,6 +12,10 @@ pub mod openapi_import;
 pub mod search;
 pub mod workflows;
 
+pub use catalog_patch::{
+    CatalogCommandMatchKey, CatalogPatchApplyError, CatalogPatchApplyRequest, CatalogPatchApplyResult, CatalogPatchOperation,
+    CatalogPatchOperationResult, CatalogPatchOperationStatus, apply_catalog_patch,
+};
 pub use clap_builder::build_clap;
 pub use config::*;
 pub use models::{CatalogHeaderEditMode, CatalogHeaderEditRow, CatalogMutationError, CatalogMutationResult, CommandRegistry};

--- a/oatty.io/dist/index.html
+++ b/oatty.io/dist/index.html
@@ -3,6 +3,46 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <script>
+        (() => {
+            const documentElement = document.documentElement;
+            documentElement.classList.add('js', 'app-pending');
+            const revealFallbackContent = () => documentElement.classList.remove('app-pending');
+            const fallbackRevealTimeoutMilliseconds = 4000;
+            const timeoutId = window.setTimeout(revealFallbackContent, fallbackRevealTimeoutMilliseconds);
+
+            if (window.customElements && typeof window.customElements.whenDefined === 'function') {
+                window.customElements
+                    .whenDefined('oatty-site-app')
+                    .then(() => {
+                        window.clearTimeout(timeoutId);
+                        revealFallbackContent();
+                    })
+                    .catch(() => {
+                        revealFallbackContent();
+                    });
+                return;
+            }
+
+            revealFallbackContent();
+        })();
+    </script>
+    <style>
+        /* Critical first-paint defaults to prevent unstyled flashes before CSS/JS load */
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            background: #12161f;
+            color: #eceff4;
+        }
+
+        .js.app-pending oatty-site-app:not(:defined) {
+            display: block;
+            min-height: 100vh;
+            visibility: hidden;
+        }
+    </style>
 
     <!-- Primary Meta Tags -->
     <title>Oatty | One CLI for Every API</title>

--- a/oatty.io/index.html
+++ b/oatty.io/index.html
@@ -3,6 +3,46 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <script>
+        (() => {
+            const documentElement = document.documentElement;
+            documentElement.classList.add('js', 'app-pending');
+            const revealFallbackContent = () => documentElement.classList.remove('app-pending');
+            const fallbackRevealTimeoutMilliseconds = 4000;
+            const timeoutId = window.setTimeout(revealFallbackContent, fallbackRevealTimeoutMilliseconds);
+
+            if (window.customElements && typeof window.customElements.whenDefined === 'function') {
+                window.customElements
+                    .whenDefined('oatty-site-app')
+                    .then(() => {
+                        window.clearTimeout(timeoutId);
+                        revealFallbackContent();
+                    })
+                    .catch(() => {
+                        revealFallbackContent();
+                    });
+                return;
+            }
+
+            revealFallbackContent();
+        })();
+    </script>
+    <style>
+        /* Critical first-paint defaults to prevent unstyled flashes before CSS/JS load */
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            background: #12161f;
+            color: #eceff4;
+        }
+
+        .js.app-pending oatty-site-app:not(:defined) {
+            display: block;
+            min-height: 100vh;
+            visibility: hidden;
+        }
+    </style>
 
     <!-- Primary Meta Tags -->
     <title>Oatty | One CLI for Every API</title>


### PR DESCRIPTION
## Summary

This PR introduces deterministic command-level catalog patching and exposes it through MCP, then refactors shared catalog persistence paths for maintainability.

### What’s included

1. Deterministic catalog patch engine in `oatty-registry`
- Added `catalog_patch` module with:
  - `CatalogPatchApplyRequest`
  - `CatalogPatchOperation`
  - `CatalogCommandMatchKey`
  - `CatalogPatchApplyResult`
  - `CatalogPatchApplyError`
  - `apply_catalog_patch(...)`
- Patch behavior:
  - Strict target match by `group + name + http_method + http_path`
  - Full `CommandSpec` replacement (no field-level merge)
  - Deterministic error behavior for missing/ambiguous targets (or skip if policy allows)
  - Rebuild provider contracts from final command set
  - Persist by replacing existing catalog entry and saving config

2. Provider contract rebuild helper in `oatty-registry-gen`
- Added `build_provider_contracts_for_commands(...)` for command-list mutation flows that do not regenerate from OpenAPI.

3. MCP support for patch application
- Added new request schemas:
  - `CatalogApplyPatchRequest`
  - `CatalogPatchOperationInput`
  - `CatalogCommandMatchKeyInput`
- Added runtime handler:
  - `apply_catalog_patch_runtime(...)`
- Added new MCP tool:
  - `catalog_apply_patch`
- Added structured error mapping for patch-specific failures.
- Updated MCP server instruction text to explicitly prefer `catalog_apply_patch` for targeted command fixes in existing catalogs.

4. Refactor: shared catalog persistence helpers
- Added internal `catalog_persistence` module to unify:
  - replace existing catalog + persist
  - insert catalog + persist
- Reused this shared path in:
  - OpenAPI import flow (`openapi_import.rs`)
  - Catalog patch flow (`catalog_patch.rs`)
- This removes duplicated disable/remove/manifest-delete/insert/save logic and lowers drift risk.

5. Ergonomics: centralized patch defaults
- Added `Default` + constructor helpers on `CatalogPatchApplyRequest`:
  - `new(...)`
  - `with_policy_overrides(...)`
- MCP mapping now delegates default policy handling to registry request construction instead of duplicating defaults at the boundary.

## Why

Current import semantics are catalog-level replace and are not suitable for partial schema overlays. This PR adds a deterministic, targeted patch workflow that:
- avoids runtime overlay complexity
- preserves a single catalog identity
- provides explicit, predictable conflict/match semantics
- improves maintainability via shared persistence utilities

## Behavior changes

- New MCP command/tool available: `catalog_apply_patch`.
- Operators/agents can patch specific broken commands in-place without re-importing a full corrected OpenAPI schema.
- Import and patch flows now share a unified persistence path in registry internals.

## Validation

Executed locally:
- `cargo fmt --all`
- `cargo check -p oatty-registry -p oatty-mcp`
- `cargo test -p oatty-registry catalog_patch`

All commands succeeded.

## Notes

- This PR does not introduce runtime multi-catalog overlay precedence.
- Existing unrelated working tree changes in `oatty.io/*` were left untouched.
