### PR TITLE
fix: keep path params out of HTTP request payloads

### DIFF
--- a/crates/mcp/src/server/core.rs
+++ b/crates/mcp/src/server/core.rs
@@ -34,7 +34,7 @@ use crate::server::workflow::{
 use anyhow::Result;
 use oatty_registry::{CommandRegistry, SearchHandle, suggest_nearest_canonical_ids};
 use oatty_types::{CommandSpec, ExecOutcome, SearchResult};
-use oatty_util::http::exec_remote_for_provider;
+use oatty_util::http::{exec_remote_for_provider_with_path_variables, extract_path_placeholder_keys};
 use reqwest::Method;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -1555,39 +1555,52 @@ async fn execute_http_command(
         (base_url, headers)
     };
 
-    let input_map = build_http_input_map(command_spec, param)?;
-    exec_remote_for_provider(command_spec, base_url.as_str(), &headers, input_map, 0)
-        .await
-        .map_err(|error| {
-            internal_error_with_next_step(
-                error.to_string(),
-                serde_json::json!({ "canonical_id": command_spec.canonical_id() }),
-                "Inspect the failing HTTP call details and retry with corrected inputs or configuration.",
-            )
-        })
+    let http_inputs = build_http_execution_inputs(command_spec, param)?;
+    exec_remote_for_provider_with_path_variables(
+        command_spec,
+        base_url.as_str(),
+        &headers,
+        http_inputs.path_variables,
+        http_inputs.payload,
+        0,
+    )
+    .await
+    .map_err(|error| {
+        internal_error_with_next_step(
+            error.to_string(),
+            serde_json::json!({ "canonical_id": command_spec.canonical_id() }),
+            "Inspect the failing HTTP call details and retry with corrected inputs or configuration.",
+        )
+    })
 }
 
-fn build_http_input_map(command_spec: &CommandSpec, param: &RunCommandRequestParam) -> Result<Map<String, Value>, ErrorData> {
+#[derive(Debug)]
+struct HttpExecutionInputs {
+    path_variables: Map<String, Value>,
+    payload: Map<String, Value>,
+}
+
+fn build_http_execution_inputs(command_spec: &CommandSpec, param: &RunCommandRequestParam) -> Result<HttpExecutionInputs, ErrorData> {
     let positional_args = param.positional_args.clone().unwrap_or_default();
     let named_flags = param.named_flags.clone().unwrap_or_default();
 
-    let flag_map = build_flag_map(command_spec, &named_flags)?;
-    let positional_strings = positional_args.clone();
-    command_spec.validate_arguments(&flag_map, &positional_strings).map_err(|error| {
-        invalid_params_with_next_step(
-            error.to_string(),
-            serde_json::json!({
-                "canonical_id": command_spec.canonical_id(),
-                "provided_positional_args": positional_args,
-                "provided_named_flags": named_flags
-            }),
-            "Call get_command or get_command_summaries_by_catalog to verify required args/flags, then retry.",
-        )
-    })?;
+    validate_http_inputs(command_spec, &positional_args, &named_flags)?;
 
-    let mut input_map = Map::new();
-    for (spec, value) in command_spec.positional_args.iter().zip(positional_args.iter()) {
-        input_map.insert(spec.name.clone(), Value::String(value.clone()));
+    let placeholder_keys = command_spec
+        .http()
+        .map(|http_spec| extract_path_placeholder_keys(http_spec.path.as_str()))
+        .unwrap_or_default();
+
+    let mut path_variables = Map::new();
+    let mut payload = Map::new();
+
+    for (specification, value) in command_spec.positional_args.iter().zip(positional_args.iter()) {
+        let json_value = Value::String(value.clone());
+        if placeholder_keys.iter().any(|key| key == specification.name.as_str()) {
+            path_variables.insert(specification.name.clone(), json_value);
+        } else {
+            payload.insert(specification.name.clone(), json_value);
+        }
     }
 
     for (name, value) in named_flags {
@@ -1602,10 +1615,30 @@ fn build_http_input_map(command_spec: &CommandSpec, param: &RunCommandRequestPar
             )
         })?;
         let normalized_value = normalize_http_flag_value(flag_spec.r#type.as_str(), value, &name)?;
-        input_map.insert(name, normalized_value);
+        payload.insert(name, normalized_value);
     }
 
-    Ok(input_map)
+    Ok(HttpExecutionInputs { path_variables, payload })
+}
+
+fn build_http_input_map(command_spec: &CommandSpec, param: &RunCommandRequestParam) -> Result<Map<String, Value>, ErrorData> {
+    Ok(build_http_execution_inputs(command_spec, param)?.payload)
+}
+
+fn validate_http_inputs(command_spec: &CommandSpec, positional_args: &[String], named_flags: &[(String, Value)]) -> Result<(), ErrorData> {
+    let flag_map = build_flag_map(command_spec, named_flags)?;
+    let positional_strings = positional_args.to_vec();
+    command_spec.validate_arguments(&flag_map, &positional_strings).map_err(|error| {
+        invalid_params_with_next_step(
+            error.to_string(),
+            serde_json::json!({
+                "canonical_id": command_spec.canonical_id(),
+                "provided_positional_args": positional_args,
+                "provided_named_flags": named_flags
+            }),
+            "Call get_command or get_command_summaries_by_catalog to verify required args/flags, then retry.",
+        )
+    })
 }
 
 fn normalize_http_flag_value(expected_type: &str, value: Value, flag_name: &str) -> Result<Value, ErrorData> {
@@ -1783,6 +1816,22 @@ mod tests {
         )
     }
 
+    fn build_http_spec_with_path_and_flag_collision() -> CommandSpec {
+        CommandSpec::new_http(
+            "github".to_string(),
+            "repos:milestones:create".to_string(),
+            "Create milestone".to_string(),
+            vec![oatty_types::PositionalArgument {
+                name: "project".to_string(),
+                help: Some("Path placeholder value".to_string()),
+                provider: None,
+            }],
+            vec![build_flag("project", "object"), build_flag("title", "string")],
+            HttpCommandSpec::new("POST", "/repos/{project}/milestones", None, None),
+            1,
+        )
+    }
+
     fn build_mcp_spec_for_flag_tests(flags: Vec<CommandFlag>) -> CommandSpec {
         CommandSpec::new_mcp(
             "vendor".to_string(),
@@ -1920,6 +1969,25 @@ mod tests {
 
         let input_map = build_http_input_map(&command_spec, &param).expect("legacy boolean flag payloads should remain supported");
         assert_eq!(input_map.get("enabled"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn build_http_execution_inputs_preserves_payload_flag_when_it_matches_path_placeholder_name() {
+        let command_spec = build_http_spec_with_path_and_flag_collision();
+        let param = RunCommandRequestParam {
+            canonical_id: command_spec.canonical_id(),
+            positional_args: Some(vec!["oattyio/oatty".to_string()]),
+            named_flags: Some(vec![
+                ("project".to_string(), json!({ "id": "body-project-id" })),
+                ("title".to_string(), json!("M1")),
+            ]),
+        };
+
+        let inputs = build_http_execution_inputs(&command_spec, &param).expect("http execution inputs should build");
+
+        assert_eq!(inputs.path_variables.get("project"), Some(&json!("oattyio/oatty")));
+        assert_eq!(inputs.payload.get("project"), Some(&json!({ "id": "body-project-id" })));
+        assert_eq!(inputs.payload.get("title"), Some(&json!("M1")));
     }
 
     #[test]

--- a/crates/mcp/src/server/core.rs
+++ b/crates/mcp/src/server/core.rs
@@ -1621,6 +1621,7 @@ fn build_http_execution_inputs(command_spec: &CommandSpec, param: &RunCommandReq
     Ok(HttpExecutionInputs { path_variables, payload })
 }
 
+#[cfg(test)]
 fn build_http_input_map(command_spec: &CommandSpec, param: &RunCommandRequestParam) -> Result<Map<String, Value>, ErrorData> {
     Ok(build_http_execution_inputs(command_spec, param)?.payload)
 }

--- a/crates/mcp/src/server/core.rs
+++ b/crates/mcp/src/server/core.rs
@@ -1621,11 +1621,6 @@ fn build_http_execution_inputs(command_spec: &CommandSpec, param: &RunCommandReq
     Ok(HttpExecutionInputs { path_variables, payload })
 }
 
-#[cfg(test)]
-fn build_http_input_map(command_spec: &CommandSpec, param: &RunCommandRequestParam) -> Result<Map<String, Value>, ErrorData> {
-    Ok(build_http_execution_inputs(command_spec, param)?.payload)
-}
-
 fn validate_http_inputs(command_spec: &CommandSpec, positional_args: &[String], named_flags: &[(String, Value)]) -> Result<(), ErrorData> {
     let flag_map = build_flag_map(command_spec, named_flags)?;
     let positional_strings = positional_args.to_vec();
@@ -1858,7 +1853,7 @@ mod tests {
     }
 
     #[test]
-    fn build_http_input_map_preserves_object_and_array_flag_values() {
+    fn build_http_execution_inputs_payload_preserves_object_and_array_flag_values() {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("project", "object"), build_flag("target", "array")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
@@ -1869,14 +1864,16 @@ mod tests {
             ]),
         };
 
-        let input_map = build_http_input_map(&command_spec, &param).expect("typed flags should build an HTTP input map");
+        let input_map = build_http_execution_inputs(&command_spec, &param)
+            .map(|inputs| inputs.payload)
+            .expect("typed flags should build an HTTP input map");
 
         assert_eq!(input_map.get("project"), Some(&json!({ "name": "demo" })));
         assert_eq!(input_map.get("target"), Some(&json!(["production", "preview"])));
     }
 
     #[test]
-    fn build_http_input_map_accepts_json_string_for_structured_flags() {
+    fn build_http_execution_inputs_payload_accepts_json_string_for_structured_flags() {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("project", "object"), build_flag("target", "array")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
@@ -1887,7 +1884,9 @@ mod tests {
             ]),
         };
 
-        let input_map = build_http_input_map(&command_spec, &param).expect("JSON text should parse for structured flags");
+        let input_map = build_http_execution_inputs(&command_spec, &param)
+            .map(|inputs| inputs.payload)
+            .expect("JSON text should parse for structured flags");
 
         assert_eq!(input_map.get("project"), Some(&json!({ "name": "demo" })));
         assert_eq!(input_map.get("target"), Some(&json!(["production", "preview"])));
@@ -1910,7 +1909,9 @@ mod tests {
         });
         let param: RunCommandRequestParam = serde_json::from_value(raw_payload).expect("MCP run_command payload should deserialize");
 
-        let input_map = build_http_input_map(&command_spec, &param).expect("deserialized flags should normalize");
+        let input_map = build_http_execution_inputs(&command_spec, &param)
+            .map(|inputs| inputs.payload)
+            .expect("deserialized flags should normalize");
 
         assert_eq!(input_map.get("project"), Some(&json!({ "name": "starter-node" })));
         assert_eq!(input_map.get("target"), Some(&json!(["production", "preview", "development"])));
@@ -1918,7 +1919,7 @@ mod tests {
     }
 
     #[test]
-    fn build_http_input_map_preserves_explicit_boolean_values() {
+    fn build_http_execution_inputs_payload_preserves_explicit_boolean_values() {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
@@ -1929,12 +1930,14 @@ mod tests {
             ]),
         };
 
-        let input_map = build_http_input_map(&command_spec, &param).expect("boolean values should normalize");
+        let input_map = build_http_execution_inputs(&command_spec, &param)
+            .map(|inputs| inputs.payload)
+            .expect("boolean values should normalize");
         assert_eq!(input_map.get("enabled"), Some(&Value::Bool(true)));
     }
 
     #[test]
-    fn build_http_input_map_supports_boolean_false() {
+    fn build_http_execution_inputs_payload_supports_boolean_false() {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
@@ -1942,7 +1945,9 @@ mod tests {
             named_flags: Some(vec![("enabled".to_string(), Value::Bool(false))]),
         };
 
-        let input_map = build_http_input_map(&command_spec, &param).expect("boolean false should be preserved");
+        let input_map = build_http_execution_inputs(&command_spec, &param)
+            .map(|inputs| inputs.payload)
+            .expect("boolean false should be preserved");
         assert_eq!(input_map.get("enabled"), Some(&Value::Bool(false)));
     }
 
@@ -1960,7 +1965,7 @@ mod tests {
     }
 
     #[test]
-    fn build_http_input_map_preserves_legacy_boolean_presence_semantics() {
+    fn build_http_execution_inputs_payload_preserves_legacy_boolean_presence_semantics() {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
@@ -1968,7 +1973,9 @@ mod tests {
             named_flags: Some(vec![("enabled".to_string(), Value::String("false".to_string()))]),
         };
 
-        let input_map = build_http_input_map(&command_spec, &param).expect("legacy boolean flag payloads should remain supported");
+        let input_map = build_http_execution_inputs(&command_spec, &param)
+            .map(|inputs| inputs.payload)
+            .expect("legacy boolean flag payloads should remain supported");
         assert_eq!(input_map.get("enabled"), Some(&Value::Bool(true)));
     }
 

--- a/crates/util/src/http/http_exec.rs
+++ b/crates/util/src/http/http_exec.rs
@@ -238,8 +238,7 @@ pub async fn exec_remote_for_provider(
 ) -> Result<ExecOutcome, String> {
     let http = spec.http().ok_or_else(|| format!("Command '{}' is not HTTP-backed", spec.name))?;
     let path_variables = extract_path_placeholder_values(http.path.as_str(), &body);
-    let payload = remove_path_placeholders_from_payload(http.path.as_str(), body);
-    exec_remote_for_provider_with_path_variables(spec, base_url, headers, path_variables, payload, request_id).await
+    exec_remote_for_provider_with_path_variables(spec, base_url, headers, path_variables, body, request_id).await
 }
 
 /// Executes an HTTP command using explicit path placeholder values and payload.
@@ -290,18 +289,6 @@ fn extract_path_placeholder_values(path_template: &str, payload: &Map<String, Va
         }
     }
     path_variables
-}
-
-/// Removes path placeholder keys from outbound payload/query parameters.
-///
-/// HTTP commands use placeholder values to hydrate request URLs. Those same
-/// values should not also be sent as query/body fields unless explicitly
-/// modeled as flags in the command schema.
-fn remove_path_placeholders_from_payload(path_template: &str, mut payload: Map<String, Value>) -> Map<String, Value> {
-    for placeholder_key in extract_path_placeholder_keys(path_template) {
-        payload.remove(placeholder_key.as_str());
-    }
-    payload
 }
 
 /// Execute a JSON-backed HTTP request and parse the response payload.
@@ -842,21 +829,6 @@ mod tests {
     }
 
     #[test]
-    fn remove_path_placeholders_from_payload_strips_path_fields_from_write_payload() {
-        let payload = Map::from_iter([
-            ("owner".to_string(), json!("oattyio")),
-            ("repo".to_string(), json!("oatty")),
-            ("title".to_string(), json!("M1 (P0 Alpha)")),
-        ]);
-
-        let sanitized = remove_path_placeholders_from_payload("/repos/{owner}/{repo}/milestones", payload);
-
-        assert!(sanitized.get("owner").is_none());
-        assert!(sanitized.get("repo").is_none());
-        assert_eq!(sanitized.get("title"), Some(&json!("M1 (P0 Alpha)")));
-    }
-
-    #[test]
     fn extract_path_placeholder_values_collects_only_placeholder_keys() {
         let payload = Map::from_iter([
             ("owner".to_string(), json!("oattyio")),
@@ -868,20 +840,5 @@ mod tests {
         assert_eq!(path_variables.get("owner"), Some(&json!("oattyio")));
         assert_eq!(path_variables.get("repo"), Some(&json!("oatty")));
         assert!(path_variables.get("title").is_none());
-    }
-
-    #[test]
-    fn remove_path_placeholders_from_payload_strips_path_fields_from_get_query_payload() {
-        let payload = Map::from_iter([
-            ("owner".to_string(), json!("oattyio")),
-            ("repo".to_string(), json!("oatty")),
-            ("state".to_string(), json!("open")),
-        ]);
-
-        let sanitized = remove_path_placeholders_from_payload("/repos/{owner}/{repo}/milestones", payload);
-
-        assert!(sanitized.get("owner").is_none());
-        assert!(sanitized.get("repo").is_none());
-        assert_eq!(sanitized.get("state"), Some(&json!("open")));
     }
 }

--- a/crates/util/src/http/http_exec.rs
+++ b/crates/util/src/http/http_exec.rs
@@ -4,7 +4,7 @@
 //! `CommandSpec`, handling headers and response parsing.
 //! It also provides a convenient `fetch_json_array` helper for list endpoints.
 
-use crate::{build_path, http, resolve_path, shell_lexing};
+use crate::{build_path, extract_path_placeholder_keys, http, resolve_path, shell_lexing};
 use anyhow::anyhow;
 use indexmap::IndexSet;
 use oatty_api::OattyClient;
@@ -238,8 +238,9 @@ pub async fn exec_remote_for_provider(
 ) -> Result<ExecOutcome, String> {
     let http = spec.http().ok_or_else(|| format!("Command '{}' is not HTTP-backed", spec.name))?;
     let path = build_path(http.path.as_str(), &body);
+    let sanitized_body = remove_path_placeholders_from_payload(http.path.as_str(), body);
 
-    match exec_remote_from_spec_inner(http, base_url, headers, body, path).await {
+    match exec_remote_from_spec_inner(http, base_url, headers, sanitized_body, path).await {
         Ok((status, _, text)) => {
             let raw_log = format!("{}\n{}", status, text);
             let mut log = summarize_execution_outcome(&spec.canonical_id(), raw_log.as_str(), status);
@@ -261,6 +262,18 @@ pub async fn exec_remote_for_provider(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Removes path placeholder keys from outbound payload/query parameters.
+///
+/// HTTP commands use placeholder values to hydrate request URLs. Those same
+/// values should not also be sent as query/body fields unless explicitly
+/// modeled as flags in the command schema.
+fn remove_path_placeholders_from_payload(path_template: &str, mut payload: Map<String, Value>) -> Map<String, Value> {
+    for placeholder_key in extract_path_placeholder_keys(path_template) {
+        payload.remove(placeholder_key.as_str());
+    }
+    payload
 }
 
 /// Execute a JSON-backed HTTP request and parse the response payload.
@@ -798,5 +811,35 @@ mod tests {
 
         let items = extract_provider_collection_items(&payload, None).expect("provider wrapper object should be extracted");
         assert_eq!(items, vec![json!({ "id": "project-a" })]);
+    }
+
+    #[test]
+    fn remove_path_placeholders_from_payload_strips_path_fields_from_write_payload() {
+        let payload = Map::from_iter([
+            ("owner".to_string(), json!("oattyio")),
+            ("repo".to_string(), json!("oatty")),
+            ("title".to_string(), json!("M1 (P0 Alpha)")),
+        ]);
+
+        let sanitized = remove_path_placeholders_from_payload("/repos/{owner}/{repo}/milestones", payload);
+
+        assert!(sanitized.get("owner").is_none());
+        assert!(sanitized.get("repo").is_none());
+        assert_eq!(sanitized.get("title"), Some(&json!("M1 (P0 Alpha)")));
+    }
+
+    #[test]
+    fn remove_path_placeholders_from_payload_strips_path_fields_from_get_query_payload() {
+        let payload = Map::from_iter([
+            ("owner".to_string(), json!("oattyio")),
+            ("repo".to_string(), json!("oatty")),
+            ("state".to_string(), json!("open")),
+        ]);
+
+        let sanitized = remove_path_placeholders_from_payload("/repos/{owner}/{repo}/milestones", payload);
+
+        assert!(sanitized.get("owner").is_none());
+        assert!(sanitized.get("repo").is_none());
+        assert_eq!(sanitized.get("state"), Some(&json!("open")));
     }
 }

--- a/crates/util/src/http/http_exec.rs
+++ b/crates/util/src/http/http_exec.rs
@@ -237,10 +237,27 @@ pub async fn exec_remote_for_provider(
     request_id: u64,
 ) -> Result<ExecOutcome, String> {
     let http = spec.http().ok_or_else(|| format!("Command '{}' is not HTTP-backed", spec.name))?;
-    let path = build_path(http.path.as_str(), &body);
-    let sanitized_body = remove_path_placeholders_from_payload(http.path.as_str(), body);
+    let path_variables = extract_path_placeholder_values(http.path.as_str(), &body);
+    let payload = remove_path_placeholders_from_payload(http.path.as_str(), body);
+    exec_remote_for_provider_with_path_variables(spec, base_url, headers, path_variables, payload, request_id).await
+}
 
-    match exec_remote_from_spec_inner(http, base_url, headers, sanitized_body, path).await {
+/// Executes an HTTP command using explicit path placeholder values and payload.
+///
+/// This variant avoids accidental key collisions where path placeholder names
+/// overlap with explicit payload fields.
+pub async fn exec_remote_for_provider_with_path_variables(
+    spec: &CommandSpec,
+    base_url: &str,
+    headers: &IndexSet<EnvVar>,
+    path_variables: Map<String, Value>,
+    payload: Map<String, Value>,
+    request_id: u64,
+) -> Result<ExecOutcome, String> {
+    let http = spec.http().ok_or_else(|| format!("Command '{}' is not HTTP-backed", spec.name))?;
+    let path = build_path(http.path.as_str(), &path_variables);
+
+    match exec_remote_from_spec_inner(http, base_url, headers, payload, path).await {
         Ok((status, _, text)) => {
             let raw_log = format!("{}\n{}", status, text);
             let mut log = summarize_execution_outcome(&spec.canonical_id(), raw_log.as_str(), status);
@@ -262,6 +279,17 @@ pub async fn exec_remote_for_provider(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Collects path placeholder values from payload map for URL hydration.
+fn extract_path_placeholder_values(path_template: &str, payload: &Map<String, Value>) -> Map<String, Value> {
+    let mut path_variables = Map::new();
+    for placeholder_key in extract_path_placeholder_keys(path_template) {
+        if let Some(value) = payload.get(placeholder_key.as_str()) {
+            path_variables.insert(placeholder_key, value.clone());
+        }
+    }
+    path_variables
 }
 
 /// Removes path placeholder keys from outbound payload/query parameters.
@@ -826,6 +854,20 @@ mod tests {
         assert!(sanitized.get("owner").is_none());
         assert!(sanitized.get("repo").is_none());
         assert_eq!(sanitized.get("title"), Some(&json!("M1 (P0 Alpha)")));
+    }
+
+    #[test]
+    fn extract_path_placeholder_values_collects_only_placeholder_keys() {
+        let payload = Map::from_iter([
+            ("owner".to_string(), json!("oattyio")),
+            ("repo".to_string(), json!("oatty")),
+            ("title".to_string(), json!("M1 (P0 Alpha)")),
+        ]);
+        let path_variables = extract_path_placeholder_values("/repos/{owner}/{repo}/milestones", &payload);
+
+        assert_eq!(path_variables.get("owner"), Some(&json!("oattyio")));
+        assert_eq!(path_variables.get("repo"), Some(&json!("oatty")));
+        assert!(path_variables.get("title").is_none());
     }
 
     #[test]

--- a/crates/util/src/http/http_path_resolution.rs
+++ b/crates/util/src/http/http_path_resolution.rs
@@ -60,6 +60,43 @@ pub fn build_path(template: &str, variables: &serde_json::Map<String, Value>) ->
     path
 }
 
+/// Extracts placeholder keys from an OpenAPI-style path template.
+///
+/// Placeholders are recognized in `{name}` segments and returned in encounter
+/// order with duplicates removed.
+///
+/// # Examples
+/// ```ignore
+/// let keys = extract_path_placeholder_keys("/repos/{owner}/{repo}/issues/{issue_number}");
+/// assert_eq!(keys, vec!["owner", "repo", "issue_number"]);
+/// ```
+pub fn extract_path_placeholder_keys(template: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut current = String::new();
+    let mut reading_placeholder = false;
+
+    for character in template.chars() {
+        match character {
+            '{' if !reading_placeholder => {
+                reading_placeholder = true;
+                current.clear();
+            }
+            '}' if reading_placeholder => {
+                let key = current.trim();
+                if !key.is_empty() && !keys.iter().any(|existing| existing == key) {
+                    keys.push(key.to_string());
+                }
+                reading_placeholder = false;
+                current.clear();
+            }
+            _ if reading_placeholder => current.push(character),
+            _ => {}
+        }
+    }
+
+    keys
+}
+
 /// Percent-encodes a path placeholder value while preserving RFC3986 unreserved bytes.
 ///
 /// Unreserved bytes (`A-Z`, `a-z`, `0-9`, `-`, `.`, `_`, `~`) are emitted as-is.
@@ -92,7 +129,7 @@ fn to_upper_hex(nibble: u8) -> char {
 
 #[cfg(test)]
 mod tests {
-    use super::build_path;
+    use super::{build_path, extract_path_placeholder_keys};
     use serde_json::{Map, Value};
 
     #[test]
@@ -111,5 +148,17 @@ mod tests {
 
         let path = build_path("/v1/projects/{project}", &variables);
         assert_eq!(path, "/v1/projects/team%2Fapp%20name");
+    }
+
+    #[test]
+    fn extract_path_placeholder_keys_returns_unique_placeholders_in_order() {
+        let keys = extract_path_placeholder_keys("/repos/{owner}/{repo}/issues/{issue_number}/{repo}");
+        assert_eq!(keys, vec!["owner", "repo", "issue_number"]);
+    }
+
+    #[test]
+    fn extract_path_placeholder_keys_ignores_empty_placeholders() {
+        let keys = extract_path_placeholder_keys("/v1/{project}//{}");
+        assert_eq!(keys, vec!["project"]);
     }
 }


### PR DESCRIPTION
## Summary
- prevent path placeholder values (for example `owner`, `repo`) from being serialized into outgoing HTTP payload/query maps
- keep placeholder values only for URL path hydration in `exec_remote_for_provider`
- add reusable path placeholder extraction helper in `http_path_resolution`
- add regression tests covering write and read/query payload sanitization

## Why
GitHub write endpoints like `POST /repos/{owner}/{repo}/milestones` reject unexpected body keys. Oatty was leaking path params into body, producing `422 "owner", "repo" are not permitted keys`.

## Testing
- `cargo test -p oatty-util http_exec -- --nocapture`
- `cargo test -p oatty-util http_path_resolution -- --nocapture`

Closes #65
