### PR TITLE
refactor: generalize command search ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,6 +2207,7 @@ dependencies = [
  "dirs-next",
  "heck",
  "indexmap",
+ "nucleo-matcher",
  "oatty-registry-gen",
  "oatty-types",
  "oatty-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ postcard = { version = "1.1.3", features = ["use-std"] }
 schemars = { version = "1.2.1", features = ["indexmap2"] }
 libc = "0.2"
 self_update = { version = "0.42.0", features = ["archive-zip", "archive-tar"] }
+nucleo-matcher = "0.3.1"
 
 [profile.release]
 opt-level = 3

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
-use clap::ArgMatches;
+use clap::{ArgMatches, parser::ValueSource};
 use indexmap::IndexSet;
 use oatty_api::OattyClient;
 use oatty_engine::workflow::document::{build_runtime_catalog, runtime_workflow_from_definition};
@@ -549,8 +549,13 @@ fn collect_positional_values(command_spec: &CommandSpec, command_matches: &ArgMa
 fn collect_request_body(command_spec: &CommandSpec, command_matches: &ArgMatches) -> Result<Map<String, Value>> {
     let mut request_body = Map::new();
     for flag in &command_spec.flags {
+        let was_explicitly_provided = matches!(
+            command_matches.value_source(&flag.name),
+            Some(ValueSource::CommandLine | ValueSource::EnvVariable)
+        );
+
         if flag.r#type == "boolean" {
-            if command_matches.get_flag(&flag.name) {
+            if was_explicitly_provided && command_matches.get_flag(&flag.name) {
                 request_body.insert(flag.name.clone(), Value::Bool(true));
             }
         } else if let Some(raw_value) = command_matches.get_one::<String>(&flag.name) {
@@ -1189,6 +1194,7 @@ mod tests {
     use oatty_engine::{
         ArgumentPrompt, BindingFailure, BindingSource, MissingReason, ProviderResolutionEvent, ProviderResolutionSource, SkipDecision,
     };
+    use oatty_registry::clap_builder::build_clap;
     use oatty_types::workflow::{RuntimeWorkflow, WorkflowDefaultSource, WorkflowInputDefault, WorkflowInputDefinition};
     use serde_json::json;
 
@@ -1305,6 +1311,39 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn collect_request_body_preserves_clap_default_values() {
+        let command_spec = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List projects".to_string(),
+            Vec::new(),
+            vec![CommandFlag {
+                name: "limit".to_string(),
+                short_name: None,
+                required: false,
+                r#type: "integer".to_string(),
+                enum_values: Vec::new(),
+                default_value: Some("10".to_string()),
+                description: Some("Maximum number of records to return.".to_string()),
+                provider: None,
+            }],
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+
+        let registry = Arc::new(Mutex::new(CommandRegistry::default().with_commands(vec![command_spec.clone()])));
+        let matches = build_clap(registry)
+            .try_get_matches_from(["oatty", "projects", "list"])
+            .expect("clap parses defaulted command");
+        let (_, group_matches) = extract_group_and_matches(&matches).expect("group matches");
+        let (_, command_matches) = extract_command_and_matches(group_matches).expect("command matches");
+
+        let request_body = collect_request_body(&command_spec, command_matches).expect("request body");
+
+        assert_eq!(request_body.get("limit"), Some(&Value::Number(serde_json::Number::from(10))));
     }
 
     #[test]

--- a/crates/mcp/src/server/core.rs
+++ b/crates/mcp/src/server/core.rs
@@ -32,7 +32,7 @@ use crate::server::workflow::{
     },
 };
 use anyhow::Result;
-use oatty_registry::{CommandRegistry, SearchHandle, canonical_id_matches_vendor, suggest_nearest_canonical_ids};
+use oatty_registry::{CommandRegistry, CommandResolutionError, ExactSearchHit, SearchHandle, suggest_nearest_canonical_ids};
 use oatty_types::{CommandSpec, ExecOutcome, SearchResult};
 use oatty_util::http::{exec_remote_for_provider_with_path_variables, extract_path_placeholder_keys};
 use reqwest::Method;
@@ -75,16 +75,7 @@ impl McpToolServices {
     }
 
     async fn search_commands(&self, query: String, vendor: Option<&str>) -> Result<Vec<SearchResult>> {
-        let mut results = self.search_handle.search_with_vendor(&query, vendor).await?;
-        let registry = self
-            .command_registry
-            .lock()
-            .map_err(|error| anyhow::anyhow!("registry lock failed: {error}"))?;
-
-        if let Some(vendor_name) = vendor {
-            results.retain(|result| vendor_matches(&registry, result, vendor_name));
-        }
-        Ok(results)
+        self.search_handle.search_with_vendor(&query, vendor).await.map_err(Into::into)
     }
 }
 
@@ -110,7 +101,7 @@ impl OattyMcpCore {
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "Find executable commands by intent. Use first before any run_* call. Use during workflow authoring to discover valid step `run` values (canonical command IDs in `<group> <command>` format, for example `apps apps:list`). Input: query, optional vendor, optional limit, optional include_inputs(none|required_only|full). Canonical direct-hit queries return exactly one result when found. include_inputs=none returns minimal discovery metadata (canonical_id, execution_type, http_method). include_inputs=required_only adds required input fields, compact provider_inputs hints, and compact output_fields. include_inputs=full adds complete positional_args, flags, provider_inputs, and output_fields. For full nested output schema, call get_command with `output_schema_detail=full`. For exact single-command inspection after discovery, use get_command with canonical_id. Authoring decision rule: if required commands are still not discoverable after two focused searches, switch to catalog_validate_openapi -> catalog_preview_import -> catalog_import_openapi before drafting workflow steps. Efficiency rule: after candidate canonical IDs are found, stop fuzzy search and switch to get_command; use at most one include_inputs=full search per vendor/intent. Routing: GET -> run_safe_command, POST/PUT/PATCH -> run_command, DELETE -> run_destructive_command, MCP -> run_safe_command or run_command."
+        description = "Find executable commands by intent. Use first before any run_* call. Use during workflow authoring to discover valid step `run` values (canonical command IDs in `<group> <command>` format, for example `apps apps:list`). Input: query, optional vendor, optional limit, optional include_inputs(none|required_only|full). Canonical direct-hit queries return exactly one result when found. include_inputs=none returns minimal discovery metadata (canonical_id, execution_type, http_method). include_inputs=required_only adds required input fields, compact provider_inputs hints, and compact output_fields. include_inputs=full adds complete positional_args, flags, provider_inputs, and output_fields. For full nested output schema, call get_command with `output_schema_detail=full`. For exact single-command inspection after discovery, use get_command with canonical_id and repeat the same vendor when you searched within one provider. Authoring decision rule: if required commands are still not discoverable after two focused searches, switch to catalog_validate_openapi -> catalog_preview_import -> catalog_import_openapi before drafting workflow steps. Efficiency rule: after candidate canonical IDs are found, stop fuzzy search and use get_command; use at most one include_inputs=full search per vendor/intent. Routing: GET -> run_safe_command, POST/PUT/PATCH -> run_command, DELETE -> run_destructive_command, MCP -> run_safe_command or run_command."
     )]
     async fn search_commands(&self, param: Parameters<SearchRequestParam>) -> Result<CallToolResult, ErrorData> {
         let request_payload = Some(serde_json::to_value(&param.0).unwrap_or(Value::Null));
@@ -174,7 +165,16 @@ impl OattyMcpCore {
             }
             let inputs_detail = param.0.include_inputs.unwrap_or_default();
             let structured = if matches!(inputs_detail, SearchInputsDetail::None) {
-                minimal_search_results(&results)
+                minimal_search_results(&self.services.command_registry, &results).map_err(|error| {
+                    internal_error_with_next_step(
+                        error.to_string(),
+                        serde_json::json!({
+                            "query": param.0.query,
+                            "include_inputs": "none"
+                        }),
+                        "Retry search_commands. If this persists, verify registry availability and MCP server health.",
+                    )
+                })?
             } else {
                 search_results_with_inputs(&self.services.command_registry, &results, inputs_detail).map_err(|error| {
                     internal_error_with_next_step(
@@ -196,15 +196,22 @@ impl OattyMcpCore {
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "Get command details by canonical_id. Defaults to compact output fields (`output_fields`) and no provider metadata. Set `output_schema_detail=full` only when full nested output schema is required. Set `include_providers=required_only|full` to include provider-backed input hints."
+        description = "Get command details by canonical_id. Defaults to compact output fields (`output_fields`) and no provider metadata. Set `output_schema_detail=full` only when full nested output schema is required. Set `include_providers=required_only|full` to include provider-backed input hints. When duplicate canonical IDs exist across vendors, pass the same vendor used during discovery."
     )]
     async fn get_command(&self, param: Parameters<CommandDetailRequest>) -> Result<CallToolResult, ErrorData> {
         let request_payload = Some(serde_json::to_value(&param.0).unwrap_or(Value::Null));
-        let result = resolve_command_spec(&self.services.command_registry, &param.0.canonical_id).map(|command_spec| {
-            let output_schema_detail = param.0.output_schema_detail.unwrap_or_default();
-            let provider_metadata_detail = param.0.include_providers.unwrap_or_default();
-            build_command_summary(&command_spec, output_schema_detail, provider_metadata_detail)
-        });
+        let result = resolve_resolved_command(&self.services.command_registry, &param.0.canonical_id, param.0.vendor.as_deref()).map(
+            |resolved_command| {
+                let output_schema_detail = param.0.output_schema_detail.unwrap_or_default();
+                let provider_metadata_detail = param.0.include_providers.unwrap_or_default();
+                build_command_summary(
+                    &resolved_command.command,
+                    resolved_command.vendor,
+                    output_schema_detail,
+                    provider_metadata_detail,
+                )
+            },
+        );
         Ok(self.finalize_structured_tool_call("get_command", request_payload, result))
     }
 
@@ -246,7 +253,7 @@ impl OattyMcpCore {
 
     #[tool(
         annotations(read_only_hint = true, open_world_hint = true),
-        description = "Execute read-only commands. Use for HTTP GET or read-only MCP commands. Input: canonical_id, positional_args[], named_flags[[name,value]]. named_flags values may be JSON scalars, arrays, or objects. Rejects write/destructive HTTP methods."
+        description = "Execute read-only commands. Use for HTTP GET or read-only MCP commands. Input: canonical_id, optional vendor, positional_args[], named_flags[[name,value]]. named_flags values may be JSON scalars, arrays, or objects. Rejects write/destructive HTTP methods."
     )]
     async fn run_safe_command(&self, param: Parameters<RunCommandRequestParam>) -> Result<CallToolResult, ErrorData> {
         let request_payload = Some(serde_json::to_value(&param.0).unwrap_or(Value::Null));
@@ -256,7 +263,7 @@ impl OattyMcpCore {
 
     #[tool(
         annotations(open_world_hint = true),
-        description = "Execute non-destructive write commands. Use for HTTP POST/PUT/PATCH or non-destructive MCP commands. Input: canonical_id, positional_args[], named_flags[[name,value]]. named_flags values may be JSON scalars, arrays, or objects. Rejects HTTP GET and DELETE."
+        description = "Execute non-destructive write commands. Use for HTTP POST/PUT/PATCH or non-destructive MCP commands. Input: canonical_id, optional vendor, positional_args[], named_flags[[name,value]]. named_flags values may be JSON scalars, arrays, or objects. Rejects HTTP GET and DELETE."
     )]
     async fn run_command(&self, param: Parameters<RunCommandRequestParam>) -> Result<CallToolResult, ErrorData> {
         let request_payload = Some(serde_json::to_value(&param.0).unwrap_or(Value::Null));
@@ -266,7 +273,7 @@ impl OattyMcpCore {
 
     #[tool(
         annotations(open_world_hint = true),
-        description = "Execute HTTP DELETE commands only. MCP commands are not allowed. Input: canonical_id, positional_args[], named_flags[[name,value]]. named_flags values may be JSON scalars, arrays, or objects."
+        description = "Execute HTTP DELETE commands only. MCP commands are not allowed. Input: canonical_id, optional vendor, positional_args[], named_flags[[name,value]]. named_flags values may be JSON scalars, arrays, or objects."
     )]
     async fn run_destructive_command(&self, param: Parameters<RunCommandRequestParam>) -> Result<CallToolResult, ErrorData> {
         let request_payload = Some(serde_json::to_value(&param.0).unwrap_or(Value::Null));
@@ -596,7 +603,7 @@ impl OattyMcpCore {
         param: &RunCommandRequestParam,
         method_guard: HttpMethodGuard,
     ) -> Result<CallToolResult, ErrorData> {
-        let command_spec = resolve_command_spec(&self.services.command_registry, &param.canonical_id)?;
+        let command_spec = resolve_command_spec(&self.services.command_registry, &param.canonical_id, param.vendor.as_deref())?;
         if let Some(http_spec) = command_spec.http() {
             let method = Method::from_str(&http_spec.method).map_err(|error| {
                 invalid_params_with_next_step(
@@ -876,52 +883,91 @@ impl HttpMethodGuard {
     }
 }
 
-fn resolve_command_spec(registry: &Arc<Mutex<CommandRegistry>>, canonical_id: &str) -> Result<CommandSpec, ErrorData> {
-    let (group, name) = split_canonical_id(canonical_id)?;
+fn resolve_command_spec(
+    registry: &Arc<Mutex<CommandRegistry>>,
+    canonical_id: &str,
+    vendor: Option<&str>,
+) -> Result<CommandSpec, ErrorData> {
+    resolve_resolved_command(registry, canonical_id, vendor).map(|resolved_command| resolved_command.command)
+}
+
+fn resolve_resolved_command(
+    registry: &Arc<Mutex<CommandRegistry>>,
+    canonical_id: &str,
+    vendor: Option<&str>,
+) -> Result<oatty_registry::ResolvedCommand, ErrorData> {
     let registry_guard = registry.lock().map_err(|error| {
         internal_error_with_next_step(
             format!("registry lock failed: {error}"),
-            serde_json::json!({ "canonical_id": canonical_id }),
+            serde_json::json!({ "canonical_id": canonical_id, "vendor": vendor }),
             "Retry the command. If this persists, restart the MCP server session.",
         )
     })?;
-    registry_guard.find_by_group_and_cmd_cloned(&group, &name).map_err(|error| {
-        let suggested_search_query = derive_search_query_from_canonical_id(canonical_id);
-        let nearest_canonical_ids = suggest_nearest_canonical_ids(&registry_guard, canonical_id, 3);
-        let next_step = format!(
-            "Use search_commands(query='{}', include_inputs='none') to discover valid canonical IDs, then call get_command and retry.",
-            suggested_search_query
-        );
-        invalid_params_with_next_step(
-            error.to_string(),
-            serde_json::json!({
-                "canonical_id": canonical_id,
-                "group": group,
-                "command": name,
-                "suggested_search_query": suggested_search_query,
-                "nearest_canonical_ids": nearest_canonical_ids,
-            }),
-            next_step.as_str(),
-        )
-    })
-}
-
-fn split_canonical_id(canonical_id: &str) -> Result<(String, String), ErrorData> {
-    parse_canonical_search_query(canonical_id).ok_or_else(|| {
-        let suggested_search_query = derive_search_query_from_canonical_id(canonical_id);
-        ErrorData::invalid_params(
-            "canonical_id must be in 'group command' format",
-            Some(serde_json::json!({
-                "expected_format": "<group> <command>",
-                "example": "apps apps:list",
-                "suggested_search_query": suggested_search_query,
-                "next_step": format!(
-                    "Do not use vendor CLI syntax directly. Call search_commands(query='{}', include_inputs='none') to discover a canonical_id first.",
-                    suggested_search_query
+    registry_guard
+        .resolve_command_by_canonical_id(canonical_id, vendor)
+        .map_err(|error| match error {
+            CommandResolutionError::InvalidCanonicalId { .. } => {
+                let suggested_search_query = derive_search_query_from_canonical_id(canonical_id);
+                ErrorData::invalid_params(
+                    "canonical_id must be in 'group command' format",
+                    Some(serde_json::json!({
+                        "suggested_search_query": suggested_search_query,
+                        "next_step": "Use search_commands to find a valid canonical_id, then retry."
+                    })),
                 )
-            })),
-        )
-    })
+            }
+            CommandResolutionError::Ambiguous {
+                canonical_id,
+                vendor,
+                matching_vendors,
+            } => invalid_params_with_next_step(
+                format!("canonical_id '{}' is ambiguous across multiple catalogs", canonical_id),
+                serde_json::json!({
+                    "canonical_id": canonical_id,
+                    "vendor": vendor,
+                    "matching_vendors": matching_vendors,
+                }),
+                "Retry with vendor set to the provider returned by search_commands.",
+            ),
+            CommandResolutionError::NotFound {
+                canonical_id,
+                group,
+                command,
+                vendor,
+                matching_vendors,
+            } => {
+                let suggested_search_query = derive_search_query_from_canonical_id(&canonical_id);
+                let nearest_canonical_ids = suggest_nearest_canonical_ids(&registry_guard, &canonical_id, 3);
+                let next_step = if vendor.is_some() && !matching_vendors.is_empty() {
+                    "Retry with the vendor used during search_commands, or omit vendor to inspect ambiguity details.".to_string()
+                } else {
+                    format!(
+                        "Use search_commands(query='{}', include_inputs='none') to discover valid canonical IDs, then call get_command and retry.",
+                        suggested_search_query
+                    )
+                };
+                invalid_params_with_next_step(
+                    if vendor.is_some() && !matching_vendors.is_empty() {
+                        format!(
+                            "no command found for canonical_id '{canonical_id}' in vendor '{}'",
+                            vendor.clone().unwrap_or_default()
+                        )
+                    } else {
+                        format!("{} {} command not found", group, command)
+                    },
+                    serde_json::json!({
+                        "canonical_id": canonical_id,
+                        "vendor": vendor,
+                        "group": group,
+                        "command": command,
+                        "matching_vendors": matching_vendors,
+                        "suggested_search_query": suggested_search_query,
+                        "nearest_canonical_ids": nearest_canonical_ids,
+                    }),
+                    next_step.as_str(),
+                )
+            }
+        })
 }
 
 fn derive_search_query_from_canonical_id(canonical_id: &str) -> String {
@@ -1003,17 +1049,24 @@ fn list_command_summaries_by_catalog(registry: &Arc<Mutex<CommandRegistry>>, cat
         .commands
         .iter()
         .filter(|command| command.catalog_identifier == catalog_index)
-        .map(|command| build_command_summary(command, OutputSchemaDetail::Paths, ProviderMetadataDetail::None))
+        .map(|command| {
+            build_command_summary(
+                command,
+                registry_guard.command_vendor(command),
+                OutputSchemaDetail::Paths,
+                ProviderMetadataDetail::None,
+            )
+        })
         .collect();
     Ok(summaries)
 }
 
-fn minimal_search_results(results: &[SearchResult]) -> Value {
+fn minimal_search_results(_registry: &Arc<Mutex<CommandRegistry>>, results: &[SearchResult]) -> Result<Value> {
     let payload = results
         .iter()
         .map(|result| Value::Object(SearchResultProjection::from_search_result(result, false).into_value_map()))
         .collect::<Vec<Value>>();
-    Value::Array(payload)
+    Ok(Value::Array(payload))
 }
 
 fn search_results_with_inputs(
@@ -1025,13 +1078,10 @@ fn search_results_with_inputs(
     let enriched = results
         .iter()
         .map(|result| {
+            let command = registry_guard.commands.get(result.index);
             let mut entry_object = SearchResultProjection::from_search_result(result, true).into_value_map();
 
-            if let Some(command) = registry_guard
-                .commands
-                .iter()
-                .find(|command| command.canonical_id() == result.canonical_id)
-            {
+            if let Some(command) = command {
                 append_command_inputs_metadata(
                     &mut entry_object,
                     command,
@@ -1049,10 +1099,11 @@ fn search_results_with_inputs(
 
 fn build_command_summary(
     command: &CommandSpec,
+    vendor: Option<String>,
     output_schema_detail: OutputSchemaDetail,
     provider_metadata_detail: ProviderMetadataDetail,
 ) -> Value {
-    let mut summary = SearchResultProjection::from_command_spec(command, true).into_value_map();
+    let mut summary = SearchResultProjection::from_command_spec(command, true, vendor).into_value_map();
     append_command_inputs_metadata(
         &mut summary,
         command,
@@ -1073,6 +1124,7 @@ struct SearchResultProjection {
     execution_type: String,
     summary: Option<String>,
     http_method: Option<String>,
+    vendor: Option<String>,
 }
 
 impl SearchResultProjection {
@@ -1082,15 +1134,17 @@ impl SearchResultProjection {
             execution_type: search_result.execution_type.clone(),
             summary: include_summary.then(|| search_result.summary.clone()),
             http_method: search_result.http_method.clone(),
+            vendor: search_result.vendor.clone(),
         }
     }
 
-    fn from_command_spec(command_spec: &CommandSpec, include_summary: bool) -> Self {
+    fn from_command_spec(command_spec: &CommandSpec, include_summary: bool, vendor: Option<String>) -> Self {
         Self {
             canonical_id: command_spec.canonical_id(),
             execution_type: command_execution_type(command_spec).to_string(),
             summary: include_summary.then(|| command_spec.summary.clone()),
             http_method: command_spec.http().map(|http_spec| http_spec.method.clone()),
+            vendor,
         }
     }
 
@@ -1103,6 +1157,9 @@ impl SearchResultProjection {
         }
         if let Some(http_method) = self.http_method.as_deref() {
             insert_non_empty_string(&mut entry_object, "http_method", http_method);
+        }
+        if let Some(vendor) = self.vendor.as_deref() {
+            insert_non_empty_string(&mut entry_object, "vendor", vendor);
         }
         entry_object
     }
@@ -1264,36 +1321,24 @@ fn prune_sparse_json(value: Value) -> Option<Value> {
     }
 }
 
-fn parse_canonical_search_query(query: &str) -> Option<(String, String)> {
-    let trimmed = query.trim();
-    let (group, command_name) = trimmed.split_once(' ')?;
-    let normalized_group = group.trim();
-    let normalized_command_name = command_name.trim();
-    if normalized_group.is_empty() || normalized_command_name.is_empty() || normalized_command_name.contains(' ') {
-        return None;
-    }
-    Some((normalized_group.to_string(), normalized_command_name.to_string()))
-}
-
 fn find_direct_search_hit(registry: &CommandRegistry, query: &str, vendor: Option<&str>) -> Option<SearchResult> {
-    let (group, command_name) = parse_canonical_search_query(query)?;
-    let command = registry.find_by_group_and_cmd_ref(&group, &command_name).ok()?;
-    let index = registry
-        .commands
-        .iter()
-        .position(|candidate| candidate.group == group && candidate.name == command_name)?;
+    let Some(ExactSearchHit::Unique(resolved_command)) = registry.resolve_exact_search_hit(query, vendor) else {
+        return None;
+    };
+    let (index, command) = registry.commands.iter().enumerate().find(|(_, candidate)| {
+        candidate.group == resolved_command.command.group
+            && candidate.name == resolved_command.command.name
+            && candidate.summary == resolved_command.command.summary
+            && registry.resolve_catalog_identifier_for_command(candidate) == resolved_command.catalog_identifier
+    })?;
     let hit = SearchResult {
         index,
         canonical_id: command.canonical_id(),
         summary: command.summary.clone(),
         execution_type: command_execution_type(command).to_string(),
         http_method: command.http().map(|http_spec| http_spec.method.clone()),
+        vendor: resolved_command.vendor,
     };
-    if let Some(vendor_name) = vendor
-        && !vendor_matches(registry, &hit, vendor_name)
-    {
-        return None;
-    }
     Some(hit)
 }
 
@@ -1765,27 +1810,17 @@ fn exec_outcome_to_value(outcome: ExecOutcome) -> Result<Value, ErrorData> {
     }
 }
 
-fn vendor_matches(registry: &CommandRegistry, result: &SearchResult, vendor_name: &str) -> bool {
-    canonical_id_matches_vendor(registry, result.canonical_id.as_str(), vendor_name)
-}
-
 fn vendor_has_enabled_command_catalog(registry: &Arc<Mutex<CommandRegistry>>, vendor_name: &str) -> Result<bool> {
     let registry_guard = registry.lock().map_err(|error| anyhow::anyhow!("registry lock failed: {error}"))?;
-    let Some(catalogs) = registry_guard.config.catalogs.as_ref() else {
-        return Ok(false);
-    };
-
-    Ok(catalogs
-        .iter()
-        .filter(|catalog| catalog.is_enabled)
-        .filter_map(|catalog| catalog.manifest.as_ref())
-        .any(|manifest| manifest.vendor.eq_ignore_ascii_case(vendor_name)))
+    Ok(registry_guard.has_enabled_catalog_for_vendor(vendor_name))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indexmap::IndexSet;
     use oatty_registry::RegistryConfig;
+    use oatty_types::manifest::{RegistryCatalog, RegistryManifest};
     use oatty_types::{CommandFlag, HttpCommandSpec, McpCommandSpec, SchemaProperty};
     use serde_json::json;
     use std::sync::{Arc, Mutex};
@@ -1847,6 +1882,7 @@ mod tests {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("project", "object"), build_flag("target", "array")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: None,
             named_flags: Some(vec![
                 ("project".to_string(), json!({ "name": "demo" })),
@@ -1867,6 +1903,7 @@ mod tests {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("project", "object"), build_flag("target", "array")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: None,
             named_flags: Some(vec![
                 ("project".to_string(), Value::String("{\"name\":\"demo\"}".to_string())),
@@ -1913,6 +1950,7 @@ mod tests {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: None,
             named_flags: Some(vec![
                 ("enabled".to_string(), Value::Bool(false)),
@@ -1931,6 +1969,7 @@ mod tests {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: None,
             named_flags: Some(vec![("enabled".to_string(), Value::Bool(false))]),
         };
@@ -1946,6 +1985,7 @@ mod tests {
         let command_spec = build_mcp_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: None,
             named_flags: Some(vec![("enabled".to_string(), Value::Bool(false))]),
         };
@@ -1959,6 +1999,7 @@ mod tests {
         let command_spec = build_http_spec_for_flag_tests(vec![build_flag("enabled", "boolean")]);
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: None,
             named_flags: Some(vec![("enabled".to_string(), Value::String("false".to_string()))]),
         };
@@ -1974,6 +2015,7 @@ mod tests {
         let command_spec = build_http_spec_with_path_and_flag_collision();
         let param = RunCommandRequestParam {
             canonical_id: command_spec.canonical_id(),
+            vendor: None,
             positional_args: Some(vec!["oattyio/oatty".to_string()]),
             named_flags: Some(vec![
                 ("project".to_string(), json!({ "id": "body-project-id" })),
@@ -1989,17 +2031,23 @@ mod tests {
     }
 
     #[test]
-    fn parse_canonical_search_query_requires_group_and_command() {
+    fn parse_canonical_command_id_requires_group_and_command() {
         assert_eq!(
-            parse_canonical_search_query("apps apps:list"),
-            Some(("apps".to_string(), "apps:list".to_string()))
+            CommandRegistry::parse_canonical_command_id("apps apps:list"),
+            Some(oatty_registry::CanonicalCommandId {
+                group: "apps".to_string(),
+                command: "apps:list".to_string(),
+            })
         );
         assert_eq!(
-            parse_canonical_search_query("  apps   apps:list  "),
-            Some(("apps".to_string(), "apps:list".to_string()))
+            CommandRegistry::parse_canonical_command_id("  apps   apps:list  "),
+            Some(oatty_registry::CanonicalCommandId {
+                group: "apps".to_string(),
+                command: "apps:list".to_string(),
+            })
         );
-        assert_eq!(parse_canonical_search_query("apps"), None);
-        assert_eq!(parse_canonical_search_query("apps apps:list extra"), None);
+        assert_eq!(CommandRegistry::parse_canonical_command_id("apps"), None);
+        assert_eq!(CommandRegistry::parse_canonical_command_id("apps apps:list extra"), None);
     }
 
     #[test]
@@ -2063,6 +2111,273 @@ mod tests {
     }
 
     #[test]
+    fn find_direct_search_hit_scopes_duplicate_canonical_ids_to_requested_vendor() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                RegistryCatalog {
+                    title: "Vercel".to_string(),
+                    description: "Vercel APIs".to_string(),
+                    vendor: Some("vercel".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.vercel.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![vercel_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "vercel".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+                RegistryCatalog {
+                    title: "Render".to_string(),
+                    description: "Render APIs".to_string(),
+                    vendor: Some("render".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.render.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![render_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "render".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+            ]),
+        };
+
+        let hit = find_direct_search_hit(&registry, "projects list", Some("render")).expect("direct hit should resolve");
+
+        assert_eq!(hit.canonical_id, "projects list");
+        assert_eq!(hit.summary, "List Render projects");
+    }
+
+    #[test]
+    fn find_direct_search_hit_returns_none_for_ambiguous_duplicate_canonical_ids() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                RegistryCatalog {
+                    title: "Vercel".to_string(),
+                    description: "Vercel APIs".to_string(),
+                    vendor: Some("vercel".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.vercel.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![vercel_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "vercel".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+                RegistryCatalog {
+                    title: "Render".to_string(),
+                    description: "Render APIs".to_string(),
+                    vendor: Some("render".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.render.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![render_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "render".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+            ]),
+        };
+
+        let hit = find_direct_search_hit(&registry, "projects list", None);
+
+        assert!(hit.is_none(), "ambiguous canonical ids should fall back to full search");
+    }
+
+    #[test]
+    fn resolve_command_spec_requires_vendor_for_duplicate_canonical_ids() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                RegistryCatalog {
+                    title: "Vercel".to_string(),
+                    description: "Vercel APIs".to_string(),
+                    vendor: Some("vercel".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.vercel.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![vercel_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "vercel".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+                RegistryCatalog {
+                    title: "Render".to_string(),
+                    description: "Render APIs".to_string(),
+                    vendor: Some("render".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.render.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![render_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "render".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+            ]),
+        };
+
+        let error = resolve_command_spec(&Arc::new(Mutex::new(registry)), "projects list", None).expect_err("resolution should fail");
+
+        assert_eq!(error.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(
+            error.message.contains("ambiguous"),
+            "expected ambiguity error message, got: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn resolve_command_spec_scopes_duplicate_canonical_ids_to_vendor() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                RegistryCatalog {
+                    title: "Vercel".to_string(),
+                    description: "Vercel APIs".to_string(),
+                    vendor: Some("vercel".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.vercel.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![vercel_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "vercel".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+                RegistryCatalog {
+                    title: "Render".to_string(),
+                    description: "Render APIs".to_string(),
+                    vendor: Some("render".to_string()),
+                    manifest_path: String::new(),
+                    import_source: None,
+                    import_source_type: None,
+                    headers: IndexSet::new(),
+                    base_urls: vec!["https://api.render.com".to_string()],
+                    base_url_index: 0,
+                    manifest: Some(RegistryManifest {
+                        commands: vec![render_projects],
+                        provider_contracts: Default::default(),
+                        vendor: "render".to_string(),
+                    }),
+                    is_enabled: true,
+                },
+            ]),
+        };
+
+        let command = resolve_command_spec(&Arc::new(Mutex::new(registry)), "projects list", Some("render"))
+            .expect("vendor-scoped resolution should succeed");
+
+        assert_eq!(command.summary, "List Render projects");
+    }
+
+    #[test]
     fn search_results_with_inputs_omits_index_field() {
         let command = CommandSpec::new_http(
             "apps".to_string(),
@@ -2082,6 +2397,7 @@ mod tests {
             summary: "List apps".to_string(),
             execution_type: "http".to_string(),
             http_method: Some("GET".to_string()),
+            vendor: None,
         }];
 
         let payload = search_results_with_inputs(&registry, &results, SearchInputsDetail::RequiredOnly).expect("payload should build");
@@ -2093,6 +2409,65 @@ mod tests {
 
         assert!(!first.contains_key("index"));
         assert_eq!(first.get("canonical_id"), Some(&Value::String("apps apps:list".to_string())));
+    }
+
+    #[test]
+    fn minimal_search_results_include_vendor_when_available() {
+        let results = vec![SearchResult {
+            index: 0,
+            canonical_id: "projects list".to_string(),
+            summary: "List Render projects".to_string(),
+            execution_type: "http".to_string(),
+            http_method: Some("GET".to_string()),
+            vendor: Some("render".to_string()),
+        }];
+
+        let payload = minimal_search_results(&Arc::new(Mutex::new(CommandRegistry::default())), &results).expect("payload should build");
+        let first = payload
+            .as_array()
+            .and_then(|items| items.first())
+            .and_then(Value::as_object)
+            .expect("first payload object");
+
+        assert_eq!(first.get("vendor"), Some(&Value::String("render".to_string())));
+    }
+
+    #[test]
+    fn vendor_has_enabled_command_catalog_uses_top_level_vendor_metadata() {
+        let command = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let mut registry = CommandRegistry::default().with_commands(vec![command.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![RegistryCatalog {
+                title: "Render".to_string(),
+                description: "Render APIs".to_string(),
+                vendor: Some("render".to_string()),
+                manifest_path: String::new(),
+                import_source: None,
+                import_source_type: None,
+                headers: IndexSet::new(),
+                base_urls: vec!["https://api.render.com".to_string()],
+                base_url_index: 0,
+                manifest: Some(RegistryManifest {
+                    commands: vec![command],
+                    provider_contracts: Default::default(),
+                    vendor: String::new(),
+                }),
+                is_enabled: true,
+            }]),
+        };
+
+        let has_vendor_catalog =
+            vendor_has_enabled_command_catalog(&Arc::new(Mutex::new(registry)), "render").expect("vendor lookup succeeds");
+
+        assert!(has_vendor_catalog, "top-level catalog vendor should satisfy the preflight check");
     }
 
     #[test]
@@ -2134,6 +2509,7 @@ mod tests {
             summary: "Create app".to_string(),
             execution_type: "http".to_string(),
             http_method: Some("POST".to_string()),
+            vendor: None,
         }];
 
         let payload = search_results_with_inputs(&registry, &results, SearchInputsDetail::RequiredOnly).expect("payload should build");
@@ -2181,7 +2557,7 @@ mod tests {
             0,
         );
 
-        let summary = build_command_summary(&command_spec, OutputSchemaDetail::Paths, ProviderMetadataDetail::None);
+        let summary = build_command_summary(&command_spec, None, OutputSchemaDetail::Paths, ProviderMetadataDetail::None);
         let object = summary.as_object().expect("command summary should be object");
         assert!(!object.contains_key("output_schema"));
     }
@@ -2208,7 +2584,7 @@ mod tests {
             0,
         );
 
-        let summary = build_command_summary(&command_spec, OutputSchemaDetail::Full, ProviderMetadataDetail::None);
+        let summary = build_command_summary(&command_spec, None, OutputSchemaDetail::Full, ProviderMetadataDetail::None);
         let object = summary.as_object().expect("command summary should be object");
         let schema = object
             .get("output_schema")
@@ -2250,7 +2626,7 @@ mod tests {
             0,
         );
 
-        let summary = build_command_summary(&command_spec, OutputSchemaDetail::Paths, ProviderMetadataDetail::None);
+        let summary = build_command_summary(&command_spec, None, OutputSchemaDetail::Paths, ProviderMetadataDetail::None);
         let object = summary.as_object().expect("command summary should be object");
         let positional = object
             .get("positional_args")
@@ -2308,7 +2684,7 @@ mod tests {
             0,
         );
 
-        let summary = build_command_summary(&command_spec, OutputSchemaDetail::Paths, ProviderMetadataDetail::RequiredOnly);
+        let summary = build_command_summary(&command_spec, None, OutputSchemaDetail::Paths, ProviderMetadataDetail::RequiredOnly);
         let flags = summary
             .as_object()
             .and_then(|object| object.get("flags"))
@@ -2352,7 +2728,7 @@ mod tests {
             0,
         );
 
-        let summary = build_command_summary(&command_spec, OutputSchemaDetail::Paths, ProviderMetadataDetail::Full);
+        let summary = build_command_summary(&command_spec, None, OutputSchemaDetail::Paths, ProviderMetadataDetail::Full);
         let positional = summary
             .as_object()
             .and_then(|object| object.get("positional_args"))

--- a/crates/mcp/src/server/core.rs
+++ b/crates/mcp/src/server/core.rs
@@ -32,7 +32,7 @@ use crate::server::workflow::{
     },
 };
 use anyhow::Result;
-use oatty_registry::{CommandRegistry, SearchHandle, suggest_nearest_canonical_ids};
+use oatty_registry::{CommandRegistry, SearchHandle, canonical_id_matches_vendor, suggest_nearest_canonical_ids};
 use oatty_types::{CommandSpec, ExecOutcome, SearchResult};
 use oatty_util::http::{exec_remote_for_provider_with_path_variables, extract_path_placeholder_keys};
 use reqwest::Method;
@@ -75,7 +75,7 @@ impl McpToolServices {
     }
 
     async fn search_commands(&self, query: String, vendor: Option<&str>) -> Result<Vec<SearchResult>> {
-        let mut results = self.search_handle.search(&query).await?;
+        let mut results = self.search_handle.search_with_vendor(&query, vendor).await?;
         let registry = self
             .command_registry
             .lock()
@@ -1766,17 +1766,7 @@ fn exec_outcome_to_value(outcome: ExecOutcome) -> Result<Value, ErrorData> {
 }
 
 fn vendor_matches(registry: &CommandRegistry, result: &SearchResult, vendor_name: &str) -> bool {
-    let canonical_id = result.canonical_id.as_str();
-    let Some(catalogs) = registry.config.catalogs.as_ref() else {
-        return false;
-    };
-
-    catalogs.iter().any(|catalog| {
-        let Some(manifest) = catalog.manifest.as_ref() else {
-            return false;
-        };
-        manifest.vendor.eq_ignore_ascii_case(vendor_name) && manifest.commands.iter().any(|command| command.canonical_id() == canonical_id)
-    })
+    canonical_id_matches_vendor(registry, result.canonical_id.as_str(), vendor_name)
 }
 
 fn vendor_has_enabled_command_catalog(registry: &Arc<Mutex<CommandRegistry>>, vendor_name: &str) -> Result<bool> {

--- a/crates/mcp/src/server/schemas.rs
+++ b/crates/mcp/src/server/schemas.rs
@@ -68,6 +68,9 @@ pub struct RunCommandRequestParam {
     /// Canonical command identifier in `<group> <command>` format.
     #[schemars(description = "Canonical command id in '<group> <command>' format, for example: 'apps apps:list'.")]
     pub canonical_id: String,
+    /// Optional vendor filter used to disambiguate duplicate canonical IDs across catalogs.
+    #[schemars(description = "Optional vendor filter used when the same canonical id exists in multiple catalogs.")]
+    pub vendor: Option<String>,
     /// Ordered positional argument values as required by the command specification.
     #[schemars(description = "Ordered positional argument values. Use command metadata order exactly.")]
     pub positional_args: Option<Vec<String>>,
@@ -94,6 +97,9 @@ pub struct CommandDetailRequest {
     /// Canonical command identifier in `<group> <command>` format.
     #[schemars(description = "Canonical command id in '<group> <command>' format, for example: 'apps apps:list'.")]
     pub canonical_id: String,
+    /// Optional vendor filter used to disambiguate duplicate canonical IDs across catalogs.
+    #[schemars(description = "Optional vendor filter used when the same canonical id exists in multiple catalogs.")]
+    pub vendor: Option<String>,
     /// Optional output schema detail level. Defaults to `paths`.
     #[schemars(description = "Optional output schema detail: paths|full. Default is paths (output_fields only).")]
     pub output_schema_detail: Option<OutputSchemaDetail>,

--- a/crates/registry/Cargo.toml
+++ b/crates/registry/Cargo.toml
@@ -23,6 +23,7 @@ postcard = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+nucleo-matcher = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -26,7 +26,7 @@ pub use openapi_import::{
     OpenApiCatalogImportError, OpenApiCatalogImportRequest, OpenApiCatalogImportResult, import_openapi_catalog_into_registry,
 };
 
-pub use search::{SearchError, SearchHandle, create_search_handle, suggest_nearest_canonical_ids};
+pub use search::{SearchError, SearchHandle, canonical_id_matches_vendor, create_search_handle, suggest_nearest_canonical_ids};
 
 #[cfg(test)]
 mod tests {

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -18,7 +18,10 @@ pub use catalog_patch::{
 };
 pub use clap_builder::build_clap;
 pub use config::*;
-pub use models::{CatalogHeaderEditMode, CatalogHeaderEditRow, CatalogMutationError, CatalogMutationResult, CommandRegistry};
+pub use models::{
+    CanonicalCommandId, CatalogHeaderEditMode, CatalogHeaderEditRow, CatalogMutationError, CatalogMutationResult, CommandRegistry,
+    CommandResolutionError, CommandResolutionResult, ExactSearchHit, ResolvedCommand,
+};
 pub use oatty_types::{
     CommandFlag, CommandSpec, ProviderArgumentContract, ProviderContract, ProviderFieldContract, ProviderReturnContract,
 };
@@ -26,7 +29,9 @@ pub use openapi_import::{
     OpenApiCatalogImportError, OpenApiCatalogImportRequest, OpenApiCatalogImportResult, import_openapi_catalog_into_registry,
 };
 
-pub use search::{SearchError, SearchHandle, canonical_id_matches_vendor, create_search_handle, suggest_nearest_canonical_ids};
+pub use search::{
+    SearchError, SearchHandle, canonical_id_matches_vendor, command_matches_vendor, create_search_handle, suggest_nearest_canonical_ids,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/registry/src/models.rs
+++ b/crates/registry/src/models.rs
@@ -17,6 +17,18 @@ const REGISTRY_EVENT_CHANNEL_CAPACITY: usize = 64;
 /// Result alias for catalog mutation operations that return typed mutation failures.
 pub type CatalogMutationResult<T> = std::result::Result<T, CatalogMutationError>;
 
+/// Result alias for canonical command resolution operations.
+pub type CommandResolutionResult<T> = std::result::Result<T, CommandResolutionError>;
+
+/// Parsed canonical identifier in `<group> <command>` form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalCommandId {
+    /// Top-level command group.
+    pub group: String,
+    /// Command name within the group.
+    pub command: String,
+}
+
 /// The main registry containing all available Oatty CLI commands.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct CommandRegistry {
@@ -80,6 +92,61 @@ pub enum CatalogMutationError {
     MissingHeaderValue {
         /// Header key missing an associated value.
         key: String,
+    },
+}
+
+/// Resolved command metadata returned by canonical-id lookups.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCommand {
+    /// Fully resolved command specification.
+    pub command: CommandSpec,
+    /// Catalog identifier that owns the resolved command when it can be determined.
+    pub catalog_identifier: Option<usize>,
+    /// Vendor name associated with the resolved command when present.
+    pub vendor: Option<String>,
+}
+
+/// Outcome for exact canonical-id search attempts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExactSearchHit {
+    /// Exactly one command matches the canonical query and optional vendor scope.
+    Unique(Box<ResolvedCommand>),
+    /// More than one command matches, so discovery should continue with ranked results.
+    Ambiguous,
+}
+
+/// Typed failures produced while resolving a canonical command identifier.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CommandResolutionError {
+    /// The canonical identifier does not follow the `<group> <command>` shape.
+    #[error("canonical_id must be in 'group command' format")]
+    InvalidCanonicalId {
+        /// User-provided canonical identifier.
+        canonical_id: String,
+    },
+    /// No command matched the requested canonical identifier and optional vendor.
+    #[error("{group} {command} command not found")]
+    NotFound {
+        /// User-provided canonical identifier.
+        canonical_id: String,
+        /// Parsed group name.
+        group: String,
+        /// Parsed command name.
+        command: String,
+        /// Optional vendor filter used during lookup.
+        vendor: Option<String>,
+        /// Vendors that contain the same canonical identifier under a different scope.
+        matching_vendors: Vec<String>,
+    },
+    /// More than one enabled catalog matched the canonical identifier.
+    #[error("canonical_id '{canonical_id}' is ambiguous across multiple catalogs")]
+    Ambiguous {
+        /// User-provided canonical identifier.
+        canonical_id: String,
+        /// Optional vendor filter used during lookup.
+        vendor: Option<String>,
+        /// Vendors that currently expose the canonical identifier.
+        matching_vendors: Vec<String>,
     },
 }
 
@@ -216,12 +283,26 @@ impl CommandRegistry {
     ///
     /// - `Ok(&CommandSpec)` - The matching command specification
     /// - `Err` - If no command is found with the given group and command name
+    ///
+    /// This legacy helper does not detect duplicate `(group, command)` pairs across vendors.
+    /// Prefer `find_by_group_and_cmd_cloned_for_vendor` or `resolve_command_by_canonical_id`
+    /// when catalogs from multiple providers can overlap.
     pub fn find_by_group_and_cmd_cloned(&self, group: &str, cmd: &str) -> Result<CommandSpec> {
         self.commands
             .iter()
             .find(|c| c.group == group && c.name == cmd)
             .cloned()
             .ok_or(anyhow!("{} {} command not found", group, cmd))
+    }
+
+    /// Finds a specific command by group, command name, and optional vendor filter.
+    pub fn find_by_group_and_cmd_cloned_for_vendor(
+        &self,
+        group: &str,
+        cmd: &str,
+        vendor: Option<&str>,
+    ) -> CommandResolutionResult<ResolvedCommand> {
+        self.resolve_command_by_canonical_id(&format!("{group} {cmd}"), vendor)
     }
 
     ///  Finds a command specification within the collection of commands, based on the provided group
@@ -237,6 +318,10 @@ impl CommandRegistry {
     ///
     ///  # Errors
     ///  Returns an error if no command in the collection matches the provided `group` and `cmd`.
+    ///
+    ///  This legacy helper does not detect duplicate `(group, command)` pairs across vendors.
+    ///  Prefer `find_by_group_and_cmd_ref_for_vendor` or `resolve_command_by_canonical_id`
+    ///  when catalogs from multiple providers can overlap.
     ///
     ///  # Example
     ///  ```ignore
@@ -254,10 +339,213 @@ impl CommandRegistry {
             .ok_or(anyhow!("{} {} command not found", group, cmd))
     }
 
+    /// Finds a specific command reference by group, command name, and optional vendor filter.
+    pub fn find_by_group_and_cmd_ref_for_vendor(
+        &self,
+        group: &str,
+        cmd: &str,
+        vendor: Option<&str>,
+    ) -> CommandResolutionResult<&CommandSpec> {
+        let resolved_command = self.find_by_group_and_cmd_cloned_for_vendor(group, cmd, vendor)?;
+        self.commands
+            .iter()
+            .find(|command| {
+                command.group == resolved_command.command.group
+                    && command.name == resolved_command.command.name
+                    && command.summary == resolved_command.command.summary
+                    && command.catalog_identifier == resolved_command.command.catalog_identifier
+            })
+            .ok_or_else(|| CommandResolutionError::NotFound {
+                canonical_id: resolved_command.command.canonical_id(),
+                group: group.to_string(),
+                command: cmd.to_string(),
+                vendor: vendor.map(ToOwned::to_owned),
+                matching_vendors: Vec::new(),
+            })
+    }
+
+    /// Parses a canonical command identifier in `<group> <command>` form.
+    pub fn parse_canonical_command_id(canonical_id: &str) -> Option<CanonicalCommandId> {
+        split_canonical_id_components(canonical_id).map(|(group, command)| CanonicalCommandId {
+            group: group.to_string(),
+            command: command.to_string(),
+        })
+    }
+
+    /// Resolves the catalog identifier for a command, accounting for stale catalog indexes.
+    pub fn resolve_catalog_identifier_for_command(&self, command: &CommandSpec) -> Option<usize> {
+        let catalogs = self.config.catalogs.as_ref()?;
+
+        if let Some(catalog) = catalogs.get(command.catalog_identifier)
+            && catalog_contains_command(catalog, command)
+        {
+            return Some(command.catalog_identifier);
+        }
+
+        let mut matching_catalog_identifiers = catalogs
+            .iter()
+            .enumerate()
+            .filter(|(_, catalog)| catalog_contains_command(catalog, command))
+            .map(|(catalog_identifier, _)| catalog_identifier);
+
+        let catalog_identifier = matching_catalog_identifiers.next()?;
+        if matching_catalog_identifiers.next().is_some() {
+            return None;
+        }
+
+        Some(catalog_identifier)
+    }
+
+    /// Returns the configured vendor for a command when it can be resolved uniquely.
+    pub fn command_vendor(&self, command: &CommandSpec) -> Option<String> {
+        let catalog_identifier = self.resolve_catalog_identifier_for_command(command)?;
+        let catalog = self.config.catalogs.as_ref()?.get(catalog_identifier)?;
+        Self::catalog_vendor_value(catalog).map(ToOwned::to_owned)
+    }
+
+    /// Returns true when a command belongs to the requested vendor.
+    pub fn command_matches_vendor(&self, command: &CommandSpec, vendor_name: &str) -> bool {
+        let Some(catalog_identifier) = self.resolve_catalog_identifier_for_command(command) else {
+            return false;
+        };
+        let Some(catalog) = self.config.catalogs.as_ref().and_then(|catalogs| catalogs.get(catalog_identifier)) else {
+            return false;
+        };
+
+        catalog.is_enabled && Self::catalog_vendor_matches(catalog, vendor_name)
+    }
+
+    /// Returns true when every enabled catalog containing the canonical identifier matches the requested vendor.
+    pub fn canonical_id_matches_vendor(&self, canonical_id: &str, vendor_name: &str) -> bool {
+        let Some(catalogs) = self.config.catalogs.as_ref() else {
+            return false;
+        };
+
+        let mut catalogs_with_command = catalogs.iter().filter(|catalog| {
+            catalog.is_enabled
+                && catalog.manifest.as_ref().is_some_and(|manifest| {
+                    manifest
+                        .commands
+                        .iter()
+                        .any(|catalog_command| catalog_command.canonical_id() == canonical_id)
+                })
+        });
+
+        let Some(first_catalog) = catalogs_with_command.next() else {
+            return false;
+        };
+
+        Self::catalog_vendor_matches(first_catalog, vendor_name)
+            && catalogs_with_command.all(|catalog| Self::catalog_vendor_matches(catalog, vendor_name))
+    }
+
+    /// Returns whether an enabled catalog exists for the requested vendor.
+    pub fn has_enabled_catalog_for_vendor(&self, vendor_name: &str) -> bool {
+        self.config.catalogs.as_ref().is_some_and(|catalogs| {
+            catalogs
+                .iter()
+                .filter(|catalog| catalog.is_enabled)
+                .any(|catalog| Self::catalog_vendor_matches(catalog, vendor_name))
+        })
+    }
+
+    /// Returns a unique exact canonical-id hit when discovery can short-circuit safely.
+    pub fn resolve_exact_search_hit(&self, query: &str, vendor: Option<&str>) -> Option<ExactSearchHit> {
+        let parsed_canonical_id = Self::parse_canonical_command_id(query)?;
+        let matching_commands = self
+            .commands
+            .iter()
+            .filter(|command| {
+                command.group == parsed_canonical_id.group
+                    && command.name == parsed_canonical_id.command
+                    && vendor.is_none_or(|vendor_name| self.command_matches_vendor(command, vendor_name))
+            })
+            .cloned()
+            .collect::<Vec<CommandSpec>>();
+
+        match matching_commands.as_slice() {
+            [command] => Some(ExactSearchHit::Unique(Box::new(ResolvedCommand {
+                catalog_identifier: self.resolve_catalog_identifier_for_command(command),
+                vendor: self.command_vendor(command),
+                command: command.clone(),
+            }))),
+            [] => None,
+            _ => Some(ExactSearchHit::Ambiguous),
+        }
+    }
+
+    /// Resolves a canonical command identifier to a unique command and vendor.
+    pub fn resolve_command_by_canonical_id(&self, canonical_id: &str, vendor: Option<&str>) -> CommandResolutionResult<ResolvedCommand> {
+        let Some(parsed_canonical_id) = Self::parse_canonical_command_id(canonical_id) else {
+            return Err(CommandResolutionError::InvalidCanonicalId {
+                canonical_id: canonical_id.to_string(),
+            });
+        };
+
+        let matching_commands = self
+            .commands
+            .iter()
+            .filter(|command| command.group == parsed_canonical_id.group && command.name == parsed_canonical_id.command)
+            .cloned()
+            .collect::<Vec<CommandSpec>>();
+        let vendor_scoped_commands = matching_commands
+            .iter()
+            .filter(|command| vendor.is_none_or(|vendor_name| self.command_matches_vendor(command, vendor_name)))
+            .cloned()
+            .collect::<Vec<CommandSpec>>();
+
+        if let [command] = vendor_scoped_commands.as_slice() {
+            return Ok(ResolvedCommand {
+                catalog_identifier: self.resolve_catalog_identifier_for_command(command),
+                vendor: self.command_vendor(command),
+                command: command.clone(),
+            });
+        }
+
+        let matching_vendors = matching_commands
+            .iter()
+            .filter_map(|command| self.command_vendor(command))
+            .collect::<std::collections::BTreeSet<String>>()
+            .into_iter()
+            .collect::<Vec<String>>();
+
+        if vendor_scoped_commands.len() > 1 || (vendor.is_none() && matching_commands.len() > 1) {
+            return Err(CommandResolutionError::Ambiguous {
+                canonical_id: canonical_id.to_string(),
+                vendor: vendor.map(ToOwned::to_owned),
+                matching_vendors,
+            });
+        }
+
+        Err(CommandResolutionError::NotFound {
+            canonical_id: canonical_id.to_string(),
+            group: parsed_canonical_id.group,
+            command: parsed_canonical_id.command,
+            vendor: vendor.map(ToOwned::to_owned),
+            matching_vendors,
+        })
+    }
+
     fn get_catalog(&self, id: usize) -> Option<&RegistryCatalog> {
         let catalogs = self.config.catalogs.as_ref()?;
 
         catalogs.get(id)
+    }
+
+    /// Returns the vendor configured for a catalog from either top-level or manifest metadata.
+    pub fn catalog_vendor_value(catalog: &RegistryCatalog) -> Option<&str> {
+        catalog
+            .vendor
+            .as_deref()
+            .or_else(|| catalog.manifest.as_ref().map(|manifest| manifest.vendor.as_str()))
+            .filter(|vendor| !vendor.trim().is_empty())
+    }
+
+    /// Returns whether the catalog belongs to the requested vendor.
+    pub fn catalog_vendor_matches(catalog: &RegistryCatalog, vendor_name: &str) -> bool {
+        let vendor_name = vendor_name.trim();
+        !vendor_name.is_empty()
+            && Self::catalog_vendor_value(catalog).is_some_and(|catalog_vendor| catalog_vendor.eq_ignore_ascii_case(vendor_name))
     }
 
     /// Inserts the synthetic commands from an MCP client's
@@ -485,6 +773,25 @@ impl CommandRegistry {
     }
 }
 
+fn split_canonical_id_components(canonical_id: &str) -> Option<(&str, &str)> {
+    let trimmed = canonical_id.trim();
+    let (group, command_name) = trimmed.split_once(' ')?;
+    let normalized_group = group.trim();
+    let normalized_command_name = command_name.trim();
+    if normalized_group.is_empty() || normalized_command_name.is_empty() || normalized_command_name.contains(' ') {
+        return None;
+    }
+
+    Some((normalized_group, normalized_command_name))
+}
+
+fn catalog_contains_command(catalog: &RegistryCatalog, command: &CommandSpec) -> bool {
+    catalog
+        .manifest
+        .as_ref()
+        .is_some_and(|manifest| manifest.commands.iter().any(|catalog_command| catalog_command == command))
+}
+
 fn apply_header_upserts(existing_headers: &IndexSet<EnvVar>, rows: &[CatalogHeaderEditRow]) -> CatalogMutationResult<IndexSet<EnvVar>> {
     let mut retained_headers = existing_headers.iter().cloned().collect::<Vec<EnvVar>>();
     for row in rows {
@@ -640,5 +947,174 @@ mod tests {
         let header = headers.iter().next().expect("single header should exist");
         assert_eq!(header.key, "authorization");
         assert_eq!(header.value, "Bearer second");
+    }
+
+    #[test]
+    fn resolve_command_by_canonical_id_requires_vendor_for_duplicate_commands() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config.catalogs = Some(vec![
+            catalog_with_commands("Vercel", "vercel", vec![vercel_projects]),
+            catalog_with_commands("Render", "render", vec![render_projects.clone()]),
+        ]);
+
+        let error = registry
+            .resolve_command_by_canonical_id("projects list", None)
+            .expect_err("duplicate commands should require vendor");
+
+        assert_eq!(
+            error,
+            CommandResolutionError::Ambiguous {
+                canonical_id: "projects list".to_string(),
+                vendor: None,
+                matching_vendors: vec!["render".to_string(), "vercel".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_command_by_canonical_id_scopes_to_vendor() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config.catalogs = Some(vec![
+            catalog_with_commands("Vercel", "vercel", vec![vercel_projects]),
+            catalog_with_commands("Render", "render", vec![render_projects.clone()]),
+        ]);
+
+        let resolved_command = registry
+            .resolve_command_by_canonical_id("projects list", Some("render"))
+            .expect("vendor-scoped resolution should succeed");
+
+        assert_eq!(resolved_command.command.summary, "List Render projects");
+        assert_eq!(resolved_command.vendor.as_deref(), Some("render"));
+        assert_eq!(resolved_command.catalog_identifier, Some(1));
+    }
+
+    #[test]
+    fn resolve_exact_search_hit_reports_ambiguity_for_duplicate_canonical_ids() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config.catalogs = Some(vec![
+            catalog_with_commands("Vercel", "vercel", vec![vercel_projects]),
+            catalog_with_commands("Render", "render", vec![render_projects]),
+        ]);
+
+        assert_eq!(
+            registry.resolve_exact_search_hit("projects list", None),
+            Some(ExactSearchHit::Ambiguous)
+        );
+    }
+
+    #[test]
+    fn resolve_catalog_identifier_recovers_stale_index_for_duplicate_canonical_ids() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects".to_string(),
+            Vec::new(),
+            Vec::new(),
+            oatty_types::command::HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config.catalogs = Some(vec![
+            catalog_with_commands("Vercel", "vercel", vec![vercel_projects]),
+            catalog_with_commands("Render", "render", vec![render_projects.clone()]),
+        ]);
+
+        registry.config.catalogs.as_mut().expect("catalogs exist").remove(0);
+        registry.commands = vec![render_projects.clone()];
+
+        let resolved_command = registry
+            .resolve_command_by_canonical_id("projects list", Some("render"))
+            .expect("stale catalog index should still resolve to the owning vendor");
+
+        assert_eq!(resolved_command.command.summary, "List Render projects");
+        assert_eq!(resolved_command.vendor.as_deref(), Some("render"));
+        assert_eq!(resolved_command.catalog_identifier, Some(0));
+    }
+
+    fn catalog_with_commands(title: &str, vendor: &str, commands: Vec<CommandSpec>) -> RegistryCatalog {
+        RegistryCatalog {
+            title: title.to_string(),
+            description: format!("{title} APIs"),
+            vendor: Some(vendor.to_string()),
+            manifest_path: String::new(),
+            import_source: None,
+            import_source_type: None,
+            headers: IndexSet::new(),
+            base_urls: vec![format!("https://api.{vendor}.com")],
+            base_url_index: 0,
+            manifest: Some(RegistryManifest {
+                commands,
+                provider_contracts: Default::default(),
+                vendor: vendor.to_string(),
+            }),
+            is_enabled: true,
+        }
     }
 }

--- a/crates/registry/src/search.rs
+++ b/crates/registry/src/search.rs
@@ -45,7 +45,7 @@ pub struct SearchHandle {
 #[derive(Debug, Default)]
 struct SearchIndexCache {
     fingerprint: Option<u64>,
-    entries: Vec<SearchIndexEntry>,
+    entries: Arc<[SearchIndexEntry]>,
 }
 
 /// Parsed search query reused across candidate scoring.
@@ -66,6 +66,7 @@ struct SearchIndexEntry {
 /// Structured search metadata derived from a command specification.
 #[derive(Debug, Clone)]
 struct SearchCandidateMetadata {
+    catalog_identifier: Option<usize>,
     canonical_id: String,
     canonical_id_lower: String,
     normalized_canonical_id_lower: String,
@@ -111,26 +112,41 @@ impl SearchHandle {
     pub async fn search_with_vendor(&self, query: &str, vendor: Option<&str>) -> Result<Vec<SearchResult>, SearchError> {
         let registry_guard = self.command_registry.lock().map_err(|error| SearchError::Lock(error.to_string()))?;
         let parsed_query = parse_search_query(query, vendor);
+        let search_index = self.get_or_build_search_index(&registry_guard)?;
         if parsed_query.normalized_text.is_empty() {
-            return Ok(Vec::new());
+            if vendor.is_none() {
+                return Ok(Vec::new());
+            }
+
+            return Ok(list_vendor_scoped_results(
+                search_index.as_ref(),
+                &registry_guard,
+                vendor,
+                self.result_limit,
+            ));
         }
 
-        let search_index = self.get_or_build_search_index(&registry_guard)?;
-        if let Some(exact_match) = search_index
-            .iter()
-            .filter(|entry| entry_matches_vendor(&registry_guard, entry, vendor))
-            .find(|entry| entry_is_exact_canonical_match(entry, &parsed_query.normalized_text))
-        {
-            return Ok(vec![exact_match.result.clone().expect("search results include projections")]);
+        if matches!(
+            registry_guard.resolve_exact_search_hit(query, vendor),
+            Some(crate::ExactSearchHit::Unique(_))
+        ) {
+            let exact_matches = search_index
+                .iter()
+                .filter(|entry| entry_matches_vendor(&registry_guard, entry, vendor))
+                .filter(|entry| entry_is_exact_canonical_match(entry, &parsed_query.normalized_text))
+                .collect::<Vec<&SearchIndexEntry>>();
+            if let [exact_match] = exact_matches.as_slice() {
+                return Ok(vec![exact_match.result.clone().expect("search results include projections")]);
+            }
         }
 
         let mut matcher = CommandSearchMatcher::default();
         let mut scored_results = search_index
-            .into_iter()
+            .iter()
             .filter(|entry| entry_matches_vendor(&registry_guard, entry, vendor))
             .filter_map(|entry| {
                 let score = matcher.score_candidate(&parsed_query, &entry.metadata)?;
-                Some((score, entry.result.expect("search results include projections")))
+                Some((score, entry.result.clone().expect("search results include projections")))
             })
             .collect::<Vec<(i64, SearchResult)>>();
 
@@ -144,7 +160,7 @@ impl SearchHandle {
     }
 
     /// Returns a cached search index for the current registry snapshot.
-    fn get_or_build_search_index(&self, registry: &CommandRegistry) -> Result<Vec<SearchIndexEntry>, SearchError> {
+    fn get_or_build_search_index(&self, registry: &CommandRegistry) -> Result<Arc<[SearchIndexEntry]>, SearchError> {
         let fingerprint = compute_registry_search_fingerprint(registry);
         let mut cache = self
             .search_index_cache
@@ -152,11 +168,11 @@ impl SearchHandle {
             .map_err(|error| SearchError::Lock(error.to_string()))?;
 
         if cache.fingerprint != Some(fingerprint) {
-            cache.entries = build_search_index(registry);
+            cache.entries = build_search_index(registry).into();
             cache.fingerprint = Some(fingerprint);
         }
 
-        Ok(cache.entries.clone())
+        Ok(Arc::clone(&cache.entries))
     }
 }
 
@@ -305,17 +321,20 @@ fn build_search_index_entry(
         summary: summary.unwrap_or_default(),
         execution_type: determine_execution_type(command).to_string(),
         http_method: command.http().map(|http_spec| http_spec.method.clone()),
+        vendor: registry.command_vendor(command),
     });
 
     SearchIndexEntry { metadata, result }
 }
 
 fn build_search_candidate_metadata(registry: &CommandRegistry, command: &CommandSpec, canonical_id: &str) -> SearchCandidateMetadata {
+    let catalog_identifier = registry.resolve_catalog_identifier_for_command(command);
     let normalized_canonical_id = normalize_identifier(canonical_id).to_ascii_lowercase();
-    let search_document = build_command_search_document(registry, command, canonical_id);
+    let search_document = build_command_search_document(registry, command, canonical_id, catalog_identifier);
     let search_document_lower = search_document.to_ascii_lowercase();
 
     SearchCandidateMetadata {
+        catalog_identifier,
         canonical_id: canonical_id.to_string(),
         canonical_id_lower: canonical_id.to_ascii_lowercase(),
         normalized_canonical_id_lower: normalized_canonical_id.clone(),
@@ -327,7 +346,12 @@ fn build_search_candidate_metadata(registry: &CommandRegistry, command: &Command
     }
 }
 
-fn build_command_search_document(registry: &CommandRegistry, command: &CommandSpec, canonical_id: &str) -> String {
+fn build_command_search_document(
+    registry: &CommandRegistry,
+    command: &CommandSpec,
+    canonical_id: &str,
+    catalog_identifier: Option<usize>,
+) -> String {
     let mut search_document = String::new();
     append_normalized_value(&mut search_document, canonical_id);
     append_normalized_value(&mut search_document, &command.group);
@@ -344,21 +368,18 @@ fn build_command_search_document(registry: &CommandRegistry, command: &CommandSp
         append_optional_normalized_value(&mut search_document, flag.description.as_deref());
     }
 
-    append_catalog_metadata(&mut search_document, registry, canonical_id);
+    append_catalog_metadata(&mut search_document, registry, catalog_identifier);
     append_mcp_metadata(&mut search_document, command.mcp());
 
     search_document
 }
 
-fn append_catalog_metadata(search_document: &mut String, registry: &CommandRegistry, canonical_id: &str) {
-    if let Some(catalog) = find_catalog_for_canonical_id(registry, canonical_id) {
+fn append_catalog_metadata(search_document: &mut String, registry: &CommandRegistry, catalog_identifier: Option<usize>) {
+    if let Some(catalog) = catalog_identifier.and_then(|identifier| registry.config.catalogs.as_ref()?.get(identifier)) {
         append_normalized_value(search_document, &catalog.title);
         append_normalized_value(search_document, &catalog.description);
-        if let Some(vendor_name) = catalog.vendor.as_deref() {
+        if let Some(vendor_name) = CommandRegistry::catalog_vendor_value(catalog) {
             append_normalized_value(search_document, vendor_name);
-        }
-        if let Some(manifest) = catalog.manifest.as_ref() {
-            append_normalized_value(search_document, &manifest.vendor);
         }
     }
 }
@@ -438,38 +459,38 @@ fn entry_matches_vendor(registry: &CommandRegistry, entry: &SearchIndexEntry, ve
         return true;
     }
 
-    canonical_id_matches_vendor(registry, &entry.metadata.canonical_id, vendor_name)
+    entry
+        .metadata
+        .catalog_identifier
+        .and_then(|catalog_identifier| registry.config.catalogs.as_ref()?.get(catalog_identifier))
+        .is_some_and(|catalog| catalog.is_enabled && CommandRegistry::catalog_vendor_matches(catalog, vendor_name))
+}
+
+fn list_vendor_scoped_results(
+    search_index: &[SearchIndexEntry],
+    registry: &CommandRegistry,
+    vendor: Option<&str>,
+    result_limit: usize,
+) -> Vec<SearchResult> {
+    let mut results = search_index
+        .iter()
+        .filter(|entry| entry_matches_vendor(registry, entry, vendor))
+        .filter_map(|entry| entry.result.clone())
+        .collect::<Vec<SearchResult>>();
+
+    results.sort_by(|left, right| left.canonical_id.cmp(&right.canonical_id));
+    results.truncate(result_limit);
+    results
 }
 
 /// Returns true when the canonical command belongs to the requested vendor.
 pub fn canonical_id_matches_vendor(registry: &CommandRegistry, canonical_id: &str, vendor_name: &str) -> bool {
-    let Some(catalogs) = registry.config.catalogs.as_ref() else {
-        return false;
-    };
-
-    catalogs.iter().any(|catalog| {
-        catalog.manifest.as_ref().is_some_and(|manifest| {
-            manifest.vendor.eq_ignore_ascii_case(vendor_name)
-                && manifest
-                    .commands
-                    .iter()
-                    .any(|catalog_command| catalog_command.canonical_id() == canonical_id)
-        })
-    })
+    registry.canonical_id_matches_vendor(canonical_id, vendor_name)
 }
 
-fn find_catalog_for_canonical_id<'a>(
-    registry: &'a CommandRegistry,
-    canonical_id: &str,
-) -> Option<&'a oatty_types::manifest::RegistryCatalog> {
-    registry.config.catalogs.as_ref()?.iter().find(|catalog| {
-        catalog.manifest.as_ref().is_some_and(|manifest| {
-            manifest
-                .commands
-                .iter()
-                .any(|catalog_command| catalog_command.canonical_id() == canonical_id)
-        })
-    })
+/// Returns true when a specific command belongs to the requested vendor.
+pub fn command_matches_vendor(registry: &CommandRegistry, command: &CommandSpec, vendor_name: &str) -> bool {
+    registry.command_matches_vendor(command, vendor_name)
 }
 
 fn normalize_identifier(value: &'_ str) -> Cow<'_, str> {
@@ -723,6 +744,16 @@ mod tests {
         assert!(results.is_empty(), "expected no matches for unmatched query");
     }
 
+    #[tokio::test]
+    async fn search_returns_empty_for_blank_query_without_vendor_scope() {
+        let registry = build_registry();
+        let handle = SearchHandle::new(registry);
+
+        let results = handle.search("   ").await.expect("search succeeds");
+
+        assert!(results.is_empty(), "expected no matches for blank query");
+    }
+
     #[test]
     fn suggest_nearest_canonical_ids_ranks_expected_match_first() {
         let registry = build_registry();
@@ -752,7 +783,7 @@ mod tests {
                 "Create deployment resources and redeploy previous deployment revisions".to_string(),
                 Vec::new(),
                 Vec::new(),
-                HttpCommandSpec::new("POST", &format!("/deployments/{index}"), None, None),
+                HttpCommandSpec::new("POST", format!("/deployments/{index}"), None, None),
                 1,
             ));
         }
@@ -978,21 +1009,148 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_with_vendor_returns_scoped_results_for_vendor_only_query() {
+        let deployment_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "create".to_string(),
+            "Create a Vercel deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v13/deployments", None, None),
+            0,
+        );
+        let project_list = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let service_scale = CommandSpec::new_http(
+            "services".to_string(),
+            "scale".to_string(),
+            "Scale a Render service.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("PATCH", "/v1/services/{id}/scale", None, None),
+            1,
+        );
+
+        let commands = vec![deployment_create.clone(), project_list.clone(), service_scale.clone()];
+        let mut registry = CommandRegistry::default().with_commands(commands);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                build_catalog("Vercel", "vercel", vec![deployment_create, project_list]),
+                build_catalog("Render", "render", vec![service_scale]),
+            ]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle.search_with_vendor("vercel", Some("vercel")).await.expect("search succeeds");
+
+        assert_eq!(results.len(), 2, "expected only vendor-scoped results");
+        assert_eq!(results[0].canonical_id, "deployments create");
+        assert_eq!(results[1].canonical_id, "projects list");
+    }
+
+    #[tokio::test]
+    async fn search_with_vendor_distinguishes_duplicate_canonical_ids_by_catalog_identity() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                build_catalog("Vercel", "vercel", vec![vercel_projects]),
+                build_catalog("Render", "render", vec![render_projects]),
+            ]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle
+            .search_with_vendor("render projects", Some("render"))
+            .await
+            .expect("search succeeds");
+
+        assert_eq!(results.len(), 1, "expected only the requested vendor command");
+        assert_eq!(results[0].canonical_id, "projects list");
+        assert_eq!(results[0].summary, "List Render projects.");
+    }
+
+    #[tokio::test]
+    async fn search_exact_duplicate_canonical_id_returns_all_matching_vendors() {
+        let vercel_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Vercel projects.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            0,
+        );
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/services", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects.clone(), render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                build_catalog("Vercel", "vercel", vec![vercel_projects]),
+                build_catalog("Render", "render", vec![render_projects]),
+            ]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle.search("projects list").await.expect("search succeeds");
+
+        assert_eq!(results.len(), 2, "duplicate canonical ids should remain visible");
+        assert_eq!(results[0].canonical_id, "projects list");
+        assert_eq!(results[1].canonical_id, "projects list");
+        assert_eq!(results[0].vendor.as_deref(), Some("vercel"));
+        assert_eq!(results[1].vendor.as_deref(), Some("render"));
+    }
+
+    #[tokio::test]
     async fn search_keeps_relevant_commands_ahead_of_noise() {
         let registry = build_heterogeneous_registry();
-        let mut registry_guard = registry.lock().expect("registry lock");
-        for index in 0..40 {
-            registry_guard.commands.push(CommandSpec::new_http(
-                format!("misc{index}"),
-                "list".to_string(),
-                "Enumerate unrelated maintenance records.".to_string(),
-                Vec::new(),
-                Vec::new(),
-                HttpCommandSpec::new("GET", &format!("/v1/misc/{index}"), None, None),
-                0,
-            ));
+        {
+            let mut registry_guard = registry.lock().expect("registry lock");
+            for index in 0..40 {
+                registry_guard.commands.push(CommandSpec::new_http(
+                    format!("misc{index}"),
+                    "list".to_string(),
+                    "Enumerate unrelated maintenance records.".to_string(),
+                    Vec::new(),
+                    Vec::new(),
+                    HttpCommandSpec::new("GET", format!("/v1/misc/{index}"), None, None),
+                    0,
+                ));
+            }
         }
-        drop(registry_guard);
 
         let handle = SearchHandle::new(registry);
         let results = handle.search("service scale").await.expect("search succeeds");

--- a/crates/registry/src/search.rs
+++ b/crates/registry/src/search.rs
@@ -1,22 +1,29 @@
 //! In-memory command search utilities.
 //!
-//! This module provides a deterministic, low-overhead search handle that queries the
-//! current in-memory command registry directly. It replaces the previous index-backed
-//! implementation and avoids background indexing threads.
+//! This module provides layered command discovery over the in-memory registry.
+//! Search candidates are normalized into reusable metadata documents and ranked
+//! with `nucleo-matcher`, while deterministic exact/token/prefix bonuses keep
+//! results stable and predictable for command-oriented queries.
 
 use std::borrow::Cow;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
-use oatty_types::{CommandSpec, SearchResult};
-use oatty_util::fuzzy_score;
+use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config as MatcherConfig, Matcher, Utf32String};
+use oatty_types::{CommandSpec, SearchResult, command::McpCommandSpec};
 use thiserror::Error;
 
 use crate::CommandRegistry;
 
 const DEFAULT_RESULT_LIMIT: usize = 20;
-const COVERAGE_SCORE_MULTIPLIER: i64 = 20;
-const EXACT_CANONICAL_MATCH_SCORE_BONUS: i64 = 50;
-const PREFIX_CANONICAL_MATCH_SCORE_BONUS: i64 = 25;
+const FUZZY_SCORE_MULTIPLIER: i64 = 100;
+const CANONICAL_PREFIX_SCORE_BONUS: i64 = 700;
+const CANONICAL_SUBSTRING_SCORE_BONUS: i64 = 250;
+const GROUP_TOKEN_SCORE_BONUS: i64 = 425;
+const TOKEN_MATCH_SCORE_BONUS: i64 = 225;
+const SUMMARY_TOKEN_SCORE_BONUS: i64 = 100;
 
 /// Errors emitted by in-memory search operations.
 #[derive(Debug, Error)]
@@ -30,7 +37,59 @@ pub enum SearchError {
 #[derive(Clone, Debug)]
 pub struct SearchHandle {
     command_registry: Arc<Mutex<CommandRegistry>>,
+    search_index_cache: Arc<Mutex<SearchIndexCache>>,
     result_limit: usize,
+}
+
+/// Cached vendor-agnostic search index keyed by a registry fingerprint.
+#[derive(Debug, Default)]
+struct SearchIndexCache {
+    fingerprint: Option<u64>,
+    entries: Vec<SearchIndexEntry>,
+}
+
+/// Parsed search query reused across candidate scoring.
+#[derive(Debug, Clone)]
+struct ParsedSearchQuery {
+    normalized_text: String,
+    tokens: Vec<String>,
+    pattern: Pattern,
+}
+
+/// Precomputed candidate data used for scoring and projection.
+#[derive(Debug, Clone)]
+struct SearchIndexEntry {
+    metadata: SearchCandidateMetadata,
+    result: Option<SearchResult>,
+}
+
+/// Structured search metadata derived from a command specification.
+#[derive(Debug, Clone)]
+struct SearchCandidateMetadata {
+    canonical_id: String,
+    canonical_id_lower: String,
+    normalized_canonical_id_lower: String,
+    canonical_tokens: Vec<String>,
+    group_tokens: Vec<String>,
+    summary_tokens: Vec<String>,
+    search_tokens: Vec<String>,
+    search_document_utf32: Utf32String,
+}
+
+/// Lightweight matcher wrapper that owns the reusable `nucleo` scratch space.
+#[derive(Debug)]
+struct CommandSearchMatcher {
+    matcher: Matcher,
+}
+
+impl Default for CommandSearchMatcher {
+    fn default() -> Self {
+        let mut configuration = MatcherConfig::DEFAULT;
+        configuration.prefer_prefix = true;
+        Self {
+            matcher: Matcher::new(configuration),
+        }
+    }
 }
 
 impl SearchHandle {
@@ -38,39 +97,40 @@ impl SearchHandle {
     pub fn new(command_registry: Arc<Mutex<CommandRegistry>>) -> Self {
         Self {
             command_registry,
+            search_index_cache: Arc::new(Mutex::new(SearchIndexCache::default())),
             result_limit: DEFAULT_RESULT_LIMIT,
         }
     }
 
-    /// Executes a fuzzy command search and returns ranked results.
+    /// Executes a structured command search and returns ranked results.
     pub async fn search(&self, query: &str) -> Result<Vec<SearchResult>, SearchError> {
-        let trimmed_query = query.trim();
-        if trimmed_query.is_empty() {
+        self.search_with_vendor(query, None).await
+    }
+
+    /// Executes a structured command search scoped to a single vendor before ranking and truncation.
+    pub async fn search_with_vendor(&self, query: &str, vendor: Option<&str>) -> Result<Vec<SearchResult>, SearchError> {
+        let registry_guard = self.command_registry.lock().map_err(|error| SearchError::Lock(error.to_string()))?;
+        let parsed_query = parse_search_query(query, vendor);
+        if parsed_query.normalized_text.is_empty() {
             return Ok(Vec::new());
         }
 
-        let query_lower = trimmed_query.to_ascii_lowercase();
-        let query_tokens = tokenize_query(trimmed_query);
-
-        let registry_guard = self.command_registry.lock().map_err(|error| SearchError::Lock(error.to_string()))?;
-
-        let mut scored_results = registry_guard
-            .commands
+        let search_index = self.get_or_build_search_index(&registry_guard)?;
+        if let Some(exact_match) = search_index
             .iter()
-            .enumerate()
-            .filter_map(|(index, command)| {
-                score_command_match(&registry_guard, command, &query_lower, &query_tokens).map(|score| {
-                    (
-                        score,
-                        SearchResult {
-                            index,
-                            canonical_id: command.canonical_id(),
-                            summary: command.summary.clone(),
-                            execution_type: determine_execution_type(command).to_string(),
-                            http_method: command.http().map(|http| http.method.clone()),
-                        },
-                    )
-                })
+            .filter(|entry| entry_matches_vendor(&registry_guard, entry, vendor))
+            .find(|entry| entry_is_exact_canonical_match(entry, &parsed_query.normalized_text))
+        {
+            return Ok(vec![exact_match.result.clone().expect("search results include projections")]);
+        }
+
+        let mut matcher = CommandSearchMatcher::default();
+        let mut scored_results = search_index
+            .into_iter()
+            .filter(|entry| entry_matches_vendor(&registry_guard, entry, vendor))
+            .filter_map(|entry| {
+                let score = matcher.score_candidate(&parsed_query, &entry.metadata)?;
+                Some((score, entry.result.expect("search results include projections")))
             })
             .collect::<Vec<(i64, SearchResult)>>();
 
@@ -82,6 +142,87 @@ impl SearchHandle {
             .map(|(_, result)| result)
             .collect())
     }
+
+    /// Returns a cached search index for the current registry snapshot.
+    fn get_or_build_search_index(&self, registry: &CommandRegistry) -> Result<Vec<SearchIndexEntry>, SearchError> {
+        let fingerprint = compute_registry_search_fingerprint(registry);
+        let mut cache = self
+            .search_index_cache
+            .lock()
+            .map_err(|error| SearchError::Lock(error.to_string()))?;
+
+        if cache.fingerprint != Some(fingerprint) {
+            cache.entries = build_search_index(registry);
+            cache.fingerprint = Some(fingerprint);
+        }
+
+        Ok(cache.entries.clone())
+    }
+}
+
+impl CommandSearchMatcher {
+    /// Score a single candidate using fuzzy ranking plus deterministic boosts.
+    fn score_candidate(&mut self, query: &ParsedSearchQuery, candidate: &SearchCandidateMetadata) -> Option<i64> {
+        let fuzzy_score = query
+            .pattern
+            .score(candidate.search_document_utf32.slice(..), &mut self.matcher)
+            .unwrap_or(0) as i64;
+        let matched_search_tokens = query
+            .tokens
+            .iter()
+            .filter(|query_token| {
+                candidate
+                    .search_tokens
+                    .iter()
+                    .any(|candidate_token| token_matches(candidate_token, query_token))
+            })
+            .count() as i64;
+        let canonical_prefix_matches = query
+            .tokens
+            .iter()
+            .filter(|query_token| {
+                candidate.canonical_tokens.iter().any(|candidate_token| {
+                    candidate_token.starts_with(query_token.as_str()) || singularize(candidate_token) == singularize(query_token)
+                })
+            })
+            .count() as i64;
+        let canonical_substring_matches = query
+            .tokens
+            .iter()
+            .filter(|query_token| candidate.normalized_canonical_id_lower.contains(query_token.as_str()))
+            .count() as i64;
+        let group_matches = query
+            .tokens
+            .iter()
+            .filter(|query_token| {
+                candidate
+                    .group_tokens
+                    .iter()
+                    .any(|group_token| token_matches(group_token, query_token))
+            })
+            .count() as i64;
+        let summary_matches = query
+            .tokens
+            .iter()
+            .filter(|query_token| {
+                candidate
+                    .summary_tokens
+                    .iter()
+                    .any(|summary_token| token_matches(summary_token, query_token))
+            })
+            .count() as i64;
+        let deterministic_score = matched_search_tokens * TOKEN_MATCH_SCORE_BONUS
+            + canonical_prefix_matches * CANONICAL_PREFIX_SCORE_BONUS
+            + canonical_substring_matches * CANONICAL_SUBSTRING_SCORE_BONUS
+            + group_matches * GROUP_TOKEN_SCORE_BONUS
+            + summary_matches * SUMMARY_TOKEN_SCORE_BONUS;
+
+        if fuzzy_score == 0 && deterministic_score == 0 {
+            return None;
+        }
+
+        Some(fuzzy_score * FUZZY_SCORE_MULTIPLIER + deterministic_score)
+    }
 }
 
 /// Creates a search handle for the provided command registry.
@@ -91,23 +232,29 @@ pub fn create_search_handle(command_registry: Arc<Mutex<CommandRegistry>>) -> Se
 
 /// Suggest nearest canonical command IDs for an arbitrary query string.
 pub fn suggest_nearest_canonical_ids(registry: &CommandRegistry, query: &str, limit: usize) -> Vec<String> {
-    let normalized_query = query.trim().to_ascii_lowercase();
-    if normalized_query.is_empty() || limit == 0 {
+    if limit == 0 {
         return Vec::new();
     }
 
+    let parsed_query = parse_search_query(query, None);
+    if parsed_query.normalized_text.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matcher = CommandSearchMatcher::default();
     let mut scored_matches = registry
         .commands
         .iter()
-        .filter_map(|command_spec| {
-            let canonical_id = command_spec.canonical_id();
-            let canonical_id_lower = canonical_id.to_ascii_lowercase();
-            let contains_bonus = if canonical_id_lower.contains(&normalized_query) { 200 } else { 0 };
-            let score = fuzzy_score(&canonical_id_lower, &normalized_query).unwrap_or(0) + contains_bonus;
-            if score <= 0 {
-                return None;
+        .map(|command_spec| build_search_index_entry(registry, None, None, command_spec))
+        .filter_map(|entry| {
+            if entry.metadata.normalized_canonical_id_lower == parsed_query.normalized_text
+                || entry.metadata.canonical_id_lower == parsed_query.normalized_text
+            {
+                return Some((i64::MAX / 4, entry.metadata.canonical_id));
             }
-            Some((score, canonical_id))
+
+            let score = matcher.score_candidate(&parsed_query, &entry.metadata)?;
+            Some((score, entry.metadata.canonical_id))
         })
         .collect::<Vec<(i64, String)>>();
 
@@ -119,38 +266,124 @@ pub fn suggest_nearest_canonical_ids(registry: &CommandRegistry, query: &str, li
         .collect()
 }
 
-fn score_command_match(registry: &CommandRegistry, command: &CommandSpec, query_lower: &str, query_tokens: &[String]) -> Option<i64> {
-    if query_tokens.is_empty() {
-        return None;
+fn parse_search_query(query: &str, vendor: Option<&str>) -> ParsedSearchQuery {
+    let vendor_token = vendor.map(|vendor_name| vendor_name.to_ascii_lowercase());
+    let tokens = tokenize_query(query)
+        .into_iter()
+        .filter(|token| vendor_token.as_ref().is_none_or(|vendor_name| token != vendor_name))
+        .collect::<Vec<String>>();
+    let normalized_text = tokens.join(" ");
+    let pattern = Pattern::new(&normalized_text, CaseMatching::Ignore, Normalization::Smart, AtomKind::Fuzzy);
+
+    ParsedSearchQuery {
+        normalized_text,
+        tokens,
+        pattern,
+    }
+}
+
+fn build_search_index(registry: &CommandRegistry) -> Vec<SearchIndexEntry> {
+    registry
+        .commands
+        .iter()
+        .enumerate()
+        .map(|(index, command)| build_search_index_entry(registry, Some(index), Some(command.summary.clone()), command))
+        .collect()
+}
+
+fn build_search_index_entry(
+    registry: &CommandRegistry,
+    index: Option<usize>,
+    summary: Option<String>,
+    command: &CommandSpec,
+) -> SearchIndexEntry {
+    let canonical_id = command.canonical_id();
+    let metadata = build_search_candidate_metadata(registry, command, &canonical_id);
+    let result = index.map(|index| SearchResult {
+        index,
+        canonical_id,
+        summary: summary.unwrap_or_default(),
+        execution_type: determine_execution_type(command).to_string(),
+        http_method: command.http().map(|http_spec| http_spec.method.clone()),
+    });
+
+    SearchIndexEntry { metadata, result }
+}
+
+fn build_search_candidate_metadata(registry: &CommandRegistry, command: &CommandSpec, canonical_id: &str) -> SearchCandidateMetadata {
+    let normalized_canonical_id = normalize_identifier(canonical_id).to_ascii_lowercase();
+    let search_document = build_command_search_document(registry, command, canonical_id);
+    let search_document_lower = search_document.to_ascii_lowercase();
+
+    SearchCandidateMetadata {
+        canonical_id: canonical_id.to_string(),
+        canonical_id_lower: canonical_id.to_ascii_lowercase(),
+        normalized_canonical_id_lower: normalized_canonical_id.clone(),
+        canonical_tokens: tokenize_query(&normalized_canonical_id),
+        group_tokens: tokenize_query(&command.group),
+        summary_tokens: tokenize_query(&command.summary),
+        search_tokens: tokenize_query(&search_document_lower),
+        search_document_utf32: Utf32String::from(search_document),
+    }
+}
+
+fn build_command_search_document(registry: &CommandRegistry, command: &CommandSpec, canonical_id: &str) -> String {
+    let mut search_document = String::new();
+    append_normalized_value(&mut search_document, canonical_id);
+    append_normalized_value(&mut search_document, &command.group);
+    append_normalized_value(&mut search_document, &command.name);
+    append_normalized_value(&mut search_document, &command.summary);
+
+    for positional_argument in &command.positional_args {
+        append_normalized_value(&mut search_document, &positional_argument.name);
+        append_optional_normalized_value(&mut search_document, positional_argument.help.as_deref());
     }
 
-    let haystack = build_command_search_haystack(registry, command);
-    let fuzzy_score_value = query_tokens.iter().try_fold(0_i64, |accumulator, token| {
-        fuzzy_score(&haystack, token).map(|token_score| accumulator + token_score)
-    })?;
-    let haystack_lower = haystack.to_ascii_lowercase();
+    for flag in &command.flags {
+        append_normalized_value(&mut search_document, &flag.name);
+        append_optional_normalized_value(&mut search_document, flag.description.as_deref());
+    }
 
-    let coverage_score =
-        query_tokens.iter().filter(|token| haystack_lower.contains(token.as_str())).count() as i64 * COVERAGE_SCORE_MULTIPLIER;
+    append_catalog_metadata(&mut search_document, registry, canonical_id);
+    append_mcp_metadata(&mut search_document, command.mcp());
 
-    let canonical_identifier_lower = command.canonical_id().to_ascii_lowercase();
-    let exact_bonus = if canonical_identifier_lower.contains(query_lower) {
-        EXACT_CANONICAL_MATCH_SCORE_BONUS
-    } else {
-        0
+    search_document
+}
+
+fn append_catalog_metadata(search_document: &mut String, registry: &CommandRegistry, canonical_id: &str) {
+    if let Some(catalog) = find_catalog_for_canonical_id(registry, canonical_id) {
+        append_normalized_value(search_document, &catalog.title);
+        append_normalized_value(search_document, &catalog.description);
+        if let Some(vendor_name) = catalog.vendor.as_deref() {
+            append_normalized_value(search_document, vendor_name);
+        }
+        if let Some(manifest) = catalog.manifest.as_ref() {
+            append_normalized_value(search_document, &manifest.vendor);
+        }
+    }
+}
+
+fn append_mcp_metadata(search_document: &mut String, mcp_command: Option<&McpCommandSpec>) {
+    let Some(mcp_command) = mcp_command else {
+        return;
     };
 
-    let prefix_bonus = if query_tokens
-        .first()
-        .map(|token| canonical_identifier_lower.starts_with(token))
-        .unwrap_or(false)
-    {
-        PREFIX_CANONICAL_MATCH_SCORE_BONUS
-    } else {
-        0
-    };
+    append_normalized_value(search_document, &mcp_command.plugin_name);
+    append_normalized_value(search_document, &mcp_command.tool_name);
+    append_optional_normalized_value(search_document, mcp_command.auth_summary.as_deref());
+    append_optional_normalized_value(search_document, mcp_command.render_hint.as_deref());
+}
 
-    Some(fuzzy_score_value + coverage_score + exact_bonus + prefix_bonus)
+fn entry_is_exact_canonical_match(entry: &SearchIndexEntry, normalized_query: &str) -> bool {
+    entry.metadata.canonical_id_lower == normalized_query || entry.metadata.normalized_canonical_id_lower == normalized_query
+}
+
+fn token_matches(candidate_token: &str, query_token: &str) -> bool {
+    candidate_token == query_token || candidate_token.starts_with(query_token) || singularize(candidate_token) == singularize(query_token)
+}
+
+fn singularize(value: &str) -> &str {
+    value.strip_suffix('s').unwrap_or(value)
 }
 
 fn determine_execution_type(command: &CommandSpec) -> &'static str {
@@ -164,7 +397,7 @@ fn determine_execution_type(command: &CommandSpec) -> &'static str {
 }
 
 fn tokenize_query(query: &str) -> Vec<String> {
-    query
+    normalize_identifier(query)
         .split_whitespace()
         .map(str::trim)
         .filter(|token| !token.is_empty())
@@ -172,61 +405,134 @@ fn tokenize_query(query: &str) -> Vec<String> {
         .collect()
 }
 
-fn build_command_search_haystack(registry: &CommandRegistry, command: &CommandSpec) -> String {
-    let mut haystack = String::new();
-    let canonical_identifier = command.canonical_id();
-    append_non_empty(&mut haystack, &canonical_identifier);
-    append_non_empty(&mut haystack, &command.summary);
-    let normalized_canonical_identifier = normalize_identifier(&canonical_identifier);
-    append_optional(&mut haystack, Some(normalized_canonical_identifier.as_ref()));
-
-    for positional_argument in &command.positional_args {
-        append_non_empty(&mut haystack, &positional_argument.name);
-        append_optional(&mut haystack, Some(normalize_identifier(&positional_argument.name).as_ref()));
-        append_optional(&mut haystack, positional_argument.help.as_deref());
+fn append_normalized_value(buffer: &mut String, value: &str) {
+    let normalized_value = normalize_identifier(value);
+    let trimmed = normalized_value.trim();
+    if trimmed.is_empty() {
+        return;
     }
 
-    for flag in &command.flags {
-        append_non_empty(&mut haystack, &flag.name);
-        append_optional(&mut haystack, Some(normalize_identifier(&flag.name).as_ref()));
-        append_optional(&mut haystack, flag.description.as_deref());
+    if !buffer.is_empty() {
+        buffer.push(' ');
     }
-
-    if let Some(catalogs) = registry.config.catalogs.as_ref()
-        && let Some(catalog) = catalogs.get(command.catalog_identifier)
-    {
-        append_non_empty(&mut haystack, &catalog.title);
-        append_non_empty(&mut haystack, &catalog.description);
-        if let Some(manifest) = catalog.manifest.as_ref() {
-            append_non_empty(&mut haystack, &manifest.vendor);
-        }
-    }
-
-    haystack
+    buffer.push_str(trimmed);
 }
 
-fn append_non_empty(buffer: &mut String, value: &str) {
-    let trimmed = value.trim();
-    if !trimmed.is_empty() {
-        if !buffer.is_empty() {
-            buffer.push(' ');
-        }
-        buffer.push_str(trimmed);
-    }
-}
-
-fn append_optional(buffer: &mut String, value: Option<&str>) {
+fn append_optional_normalized_value(buffer: &mut String, value: Option<&str>) {
     if let Some(value) = value {
-        append_non_empty(buffer, value);
+        append_normalized_value(buffer, value);
     }
+}
+
+fn entry_matches_vendor(registry: &CommandRegistry, entry: &SearchIndexEntry, vendor: Option<&str>) -> bool {
+    let Some(vendor_name) = vendor else {
+        return true;
+    };
+
+    let Some(catalogs) = registry.config.catalogs.as_ref() else {
+        return true;
+    };
+
+    let saw_manifest_metadata = catalogs.iter().any(|catalog| catalog.manifest.is_some());
+    if !saw_manifest_metadata {
+        return true;
+    }
+
+    canonical_id_matches_vendor(registry, &entry.metadata.canonical_id, vendor_name)
+}
+
+/// Returns true when the canonical command belongs to the requested vendor.
+pub fn canonical_id_matches_vendor(registry: &CommandRegistry, canonical_id: &str, vendor_name: &str) -> bool {
+    let Some(catalogs) = registry.config.catalogs.as_ref() else {
+        return false;
+    };
+
+    catalogs.iter().any(|catalog| {
+        catalog.manifest.as_ref().is_some_and(|manifest| {
+            manifest.vendor.eq_ignore_ascii_case(vendor_name)
+                && manifest
+                    .commands
+                    .iter()
+                    .any(|catalog_command| catalog_command.canonical_id() == canonical_id)
+        })
+    })
+}
+
+fn find_catalog_for_canonical_id<'a>(
+    registry: &'a CommandRegistry,
+    canonical_id: &str,
+) -> Option<&'a oatty_types::manifest::RegistryCatalog> {
+    registry.config.catalogs.as_ref()?.iter().find(|catalog| {
+        catalog.manifest.as_ref().is_some_and(|manifest| {
+            manifest
+                .commands
+                .iter()
+                .any(|catalog_command| catalog_command.canonical_id() == canonical_id)
+        })
+    })
 }
 
 fn normalize_identifier(value: &'_ str) -> Cow<'_, str> {
-    if value.bytes().any(|byte| matches!(byte, b'_' | b'-' | b'.')) {
-        Cow::Owned(value.replace(['_', '-', '.'], " "))
+    if value.bytes().any(|byte| matches!(byte, b'_' | b'-' | b'.' | b':' | b'/' | b'\\')) {
+        Cow::Owned(value.replace(['_', '-', '.', ':', '/', '\\'], " "))
     } else {
         Cow::Borrowed(value)
     }
+}
+
+fn compute_registry_search_fingerprint(registry: &CommandRegistry) -> u64 {
+    let mut hasher = DefaultHasher::new();
+
+    for command in &registry.commands {
+        command.group.hash(&mut hasher);
+        command.name.hash(&mut hasher);
+        command.summary.hash(&mut hasher);
+        command.catalog_identifier.hash(&mut hasher);
+
+        for positional_argument in &command.positional_args {
+            positional_argument.name.hash(&mut hasher);
+            positional_argument.help.hash(&mut hasher);
+        }
+
+        for flag in &command.flags {
+            flag.name.hash(&mut hasher);
+            flag.short_name.hash(&mut hasher);
+            flag.required.hash(&mut hasher);
+            flag.r#type.hash(&mut hasher);
+            flag.enum_values.hash(&mut hasher);
+            flag.default_value.hash(&mut hasher);
+            flag.description.hash(&mut hasher);
+        }
+
+        if let Some(http_command) = command.http() {
+            http_command.method.hash(&mut hasher);
+            http_command.path.hash(&mut hasher);
+        }
+        if let Some(mcp_command) = command.mcp() {
+            mcp_command.plugin_name.hash(&mut hasher);
+            mcp_command.tool_name.hash(&mut hasher);
+            mcp_command.auth_summary.hash(&mut hasher);
+            mcp_command.render_hint.hash(&mut hasher);
+        }
+    }
+
+    if let Some(catalogs) = registry.config.catalogs.as_ref() {
+        for catalog in catalogs {
+            catalog.title.hash(&mut hasher);
+            catalog.description.hash(&mut hasher);
+            catalog.vendor.hash(&mut hasher);
+            catalog.is_enabled.hash(&mut hasher);
+
+            if let Some(manifest) = catalog.manifest.as_ref() {
+                manifest.vendor.hash(&mut hasher);
+                for command in &manifest.commands {
+                    command.canonical_id().hash(&mut hasher);
+                }
+            }
+        }
+    }
+
+    hasher.finish()
 }
 
 #[cfg(test)]
@@ -236,6 +542,7 @@ mod tests {
     use indexmap::IndexSet;
     use oatty_types::command::HttpCommandSpec;
     use oatty_types::manifest::{RegistryCatalog, RegistryManifest};
+    use oatty_types::{CommandFlag, McpCommandSpec};
 
     use crate::RegistryConfig;
 
@@ -260,49 +567,136 @@ mod tests {
             1,
         );
 
-        let vercel_manifest = RegistryManifest {
-            commands: vec![vercel_projects.clone()],
-            provider_contracts: Default::default(),
-            vendor: "vercel".to_string(),
-        };
-
-        let render_manifest = RegistryManifest {
-            commands: vec![render_services.clone()],
-            provider_contracts: Default::default(),
-            vendor: "render".to_string(),
-        };
-
-        let vercel_catalog = RegistryCatalog {
-            title: "Vercel".to_string(),
-            description: "Vercel platform API".to_string(),
-            vendor: Some("vercel".to_string()),
-            manifest_path: String::new(),
-            import_source: None,
-            import_source_type: None,
-            headers: IndexSet::new(),
-            base_urls: vec!["https://api.vercel.com".to_string()],
-            base_url_index: 0,
-            manifest: Some(vercel_manifest),
-            is_enabled: true,
-        };
-
-        let render_catalog = RegistryCatalog {
-            title: "Render".to_string(),
-            description: "Render platform API".to_string(),
-            vendor: Some("render".to_string()),
-            manifest_path: String::new(),
-            import_source: None,
-            import_source_type: None,
-            headers: IndexSet::new(),
-            base_urls: vec!["https://api.render.com".to_string()],
-            base_url_index: 0,
-            manifest: Some(render_manifest),
-            is_enabled: true,
-        };
+        let vercel_catalog = build_catalog("Vercel", "vercel", vec![vercel_projects.clone()]);
+        let render_catalog = build_catalog("Render", "render", vec![render_services.clone()]);
 
         let mut registry = CommandRegistry::default().with_commands(vec![vercel_projects, render_services]);
         registry.config = RegistryConfig {
             catalogs: Some(vec![vercel_catalog, render_catalog]),
+        };
+
+        Arc::new(Mutex::new(registry))
+    }
+
+    fn build_catalog(title: &str, vendor: &str, commands: Vec<CommandSpec>) -> RegistryCatalog {
+        RegistryCatalog {
+            title: title.to_string(),
+            description: format!("{title} platform API"),
+            vendor: Some(vendor.to_string()),
+            manifest_path: String::new(),
+            import_source: None,
+            import_source_type: None,
+            headers: IndexSet::new(),
+            base_urls: vec![format!("https://api.{vendor}.com")],
+            base_url_index: 0,
+            manifest: Some(RegistryManifest {
+                commands,
+                provider_contracts: Default::default(),
+                vendor: vendor.to_string(),
+            }),
+            is_enabled: true,
+        }
+    }
+
+    fn build_heterogeneous_registry() -> Arc<Mutex<CommandRegistry>> {
+        let deployment_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "create".to_string(),
+            "Create a new deployment from the current revision.".to_string(),
+            Vec::new(),
+            vec![CommandFlag {
+                name: "git-ref".to_string(),
+                short_name: None,
+                description: Some("Git ref to build and deploy.".to_string()),
+                r#type: "string".to_string(),
+                required: false,
+                default_value: None,
+                enum_values: Vec::new(),
+                provider: None,
+            }],
+            HttpCommandSpec::new("POST", "/v13/deployments", None, None),
+            0,
+        );
+        let deployment_info = CommandSpec::new_http(
+            "deployments".to_string(),
+            "info".to_string(),
+            "Retrieve information about a deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v13/deployments/{id}", None, None),
+            0,
+        );
+        let domain_verify = CommandSpec::new_http(
+            "projects".to_string(),
+            "domains:verify".to_string(),
+            "Verify project domain ownership with DNS challenge details.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v1/projects/domains/verify", None, None),
+            0,
+        );
+        let check_rerequest = CommandSpec::new_http(
+            "deployments".to_string(),
+            "checks:rerequest:create".to_string(),
+            "Rerequest a failed deployment check run.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v1/deployments/checks/rerequest", None, None),
+            0,
+        );
+        let services_scale = CommandSpec::new_http(
+            "services".to_string(),
+            "scale".to_string(),
+            "Scale a service to the requested instance count.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("PATCH", "/v1/services/{id}/scale", None, None),
+            1,
+        );
+        let tokens_rotate = CommandSpec::new_http(
+            "tokens".to_string(),
+            "rotate".to_string(),
+            "Rotate an access token without changing downstream clients.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v1/tokens/{id}/rotate", None, None),
+            1,
+        );
+        let github_issue_sync = CommandSpec::new_mcp(
+            "github".to_string(),
+            "issues:sync".to_string(),
+            "Synchronize GitHub issues into the local tracker.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            McpCommandSpec {
+                plugin_name: "github".to_string(),
+                tool_name: "sync_issues".to_string(),
+                auth_summary: Some("GitHub OAuth required".to_string()),
+                output_schema: None,
+                render_hint: Some("results".to_string()),
+            },
+        );
+
+        let commands = vec![
+            deployment_create.clone(),
+            deployment_info.clone(),
+            domain_verify.clone(),
+            check_rerequest.clone(),
+            services_scale.clone(),
+            tokens_rotate.clone(),
+            github_issue_sync.clone(),
+        ];
+
+        let mut registry = CommandRegistry::default().with_commands(commands);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                build_catalog(
+                    "Vercel",
+                    "vercel",
+                    vec![deployment_create, deployment_info, domain_verify, check_rerequest],
+                ),
+                build_catalog("Render", "render", vec![services_scale, tokens_rotate]),
+            ]),
         };
 
         Arc::new(Mutex::new(registry))
@@ -336,5 +730,279 @@ mod tests {
         let suggestions = suggest_nearest_canonical_ids(&registry_guard, "projects project:list", 3);
         assert!(!suggestions.is_empty(), "expected non-empty suggestions");
         assert_eq!(suggestions[0], "projects projects:list");
+    }
+
+    #[tokio::test]
+    async fn search_with_vendor_filters_before_result_limit() {
+        let deployment_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "create".to_string(),
+            "Create a new deployment with all the required and intended data.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v13/deployments", None, None),
+            0,
+        );
+
+        let mut noise_commands = Vec::new();
+        for index in 0..25 {
+            noise_commands.push(CommandSpec::new_http(
+                format!("deployments{index}"),
+                "create".to_string(),
+                "Create deployment resources and redeploy previous deployment revisions".to_string(),
+                Vec::new(),
+                Vec::new(),
+                HttpCommandSpec::new("POST", &format!("/deployments/{index}"), None, None),
+                1,
+            ));
+        }
+
+        let mut commands = vec![deployment_create.clone()];
+        commands.extend(noise_commands.clone());
+
+        let mut registry = CommandRegistry::default().with_commands(commands);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![
+                build_catalog("Vercel", "vercel", vec![deployment_create]),
+                build_catalog("Render", "render", noise_commands),
+            ]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle
+            .search_with_vendor("vercel deployment create redeploy previous deployment", Some("vercel"))
+            .await
+            .expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected a vendor-scoped result");
+        assert_eq!(results[0].canonical_id, "deployments create");
+    }
+
+    #[tokio::test]
+    async fn search_with_vendor_handles_verbose_natural_language_query() {
+        let deployment_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "create".to_string(),
+            "Create a new deployment with all the required and intended data. Additionally, a deployment id can be specified to redeploy a previous deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v13/deployments", None, None),
+            0,
+        );
+        let deployment_check_runs_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "check-runs:create".to_string(),
+            "Creates a new check run for a deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v1/deployments/check-runs", None, None),
+            0,
+        );
+        let deployment_checks_rerequest_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "checks:rerequest:create".to_string(),
+            "Rerequest a selected check that has failed.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v1/deployments/checks/rerequest", None, None),
+            0,
+        );
+        let deployment_info = CommandSpec::new_http(
+            "deployments".to_string(),
+            "info".to_string(),
+            "Retrieves information for a deployment either by supplying its ID or hostname.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v13/deployments/{idOrUrl}", None, None),
+            0,
+        );
+        let files_create = CommandSpec::new_http(
+            "files".to_string(),
+            "create".to_string(),
+            "Before you create a deployment you need to upload the required files for that deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v2/files", None, None),
+            0,
+        );
+        let projects_promote_create = CommandSpec::new_http(
+            "projects".to_string(),
+            "promote:create".to_string(),
+            "Allows users to promote a deployment to production. Note: This does NOT rebuild the deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v1/projects/promote", None, None),
+            0,
+        );
+
+        let commands = vec![
+            deployment_create.clone(),
+            deployment_check_runs_create.clone(),
+            deployment_checks_rerequest_create.clone(),
+            deployment_info.clone(),
+            files_create.clone(),
+            projects_promote_create.clone(),
+        ];
+
+        let mut registry = CommandRegistry::default().with_commands(commands.clone());
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![build_catalog("Vercel", "vercel", commands)]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle
+            .search_with_vendor(
+                "vercel deployment create new deployment redeploy clone existing deployment build from git ref",
+                Some("vercel"),
+            )
+            .await
+            .expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected a vendor-scoped result");
+        assert_eq!(results[0].canonical_id, "deployments create");
+    }
+
+    #[tokio::test]
+    async fn search_exact_canonical_hit_short_circuits() {
+        let registry = build_heterogeneous_registry();
+        let handle = SearchHandle::new(registry);
+
+        let results = handle.search("deployments checks:rerequest:create").await.expect("search succeeds");
+
+        assert_eq!(results.len(), 1, "expected direct canonical match only");
+        assert_eq!(results[0].canonical_id, "deployments checks:rerequest:create");
+    }
+
+    #[tokio::test]
+    async fn search_ranks_nested_command_names_from_spaced_query() {
+        let registry = build_heterogeneous_registry();
+        let handle = SearchHandle::new(registry);
+
+        let results = handle.search("project domain verify").await.expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected nested command match");
+        assert_eq!(results[0].canonical_id, "projects domains:verify");
+    }
+
+    #[tokio::test]
+    async fn search_treats_deployment_as_a_resource_hint() {
+        let deployment_create = CommandSpec::new_http(
+            "deployments".to_string(),
+            "create".to_string(),
+            "Create a deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("POST", "/v13/deployments", None, None),
+            0,
+        );
+        let deployment_delete = CommandSpec::new_http(
+            "deployments".to_string(),
+            "delete".to_string(),
+            "Delete a deployment.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("DELETE", "/v13/deployments/{id}", None, None),
+            0,
+        );
+        let deployment_info = CommandSpec::new_http(
+            "deployments".to_string(),
+            "info".to_string(),
+            "Retrieve deployment details.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v13/deployments/{id}", None, None),
+            0,
+        );
+
+        let commands = vec![deployment_create, deployment_delete, deployment_info];
+        let mut registry = CommandRegistry::default().with_commands(commands.clone());
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![build_catalog("Vercel", "vercel", commands)]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle.search("deployment delete").await.expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected search results");
+        assert_eq!(results[0].canonical_id, "deployments delete");
+    }
+
+    #[tokio::test]
+    async fn search_matches_provider_specific_verbs_without_custom_aliases() {
+        let registry = build_heterogeneous_registry();
+        let handle = SearchHandle::new(registry);
+
+        let results = handle.search("token rotate").await.expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected token rotation result");
+        assert_eq!(results[0].canonical_id, "tokens rotate");
+    }
+
+    #[tokio::test]
+    async fn search_can_rank_mcp_and_http_commands_together() {
+        let registry = build_heterogeneous_registry();
+        let handle = SearchHandle::new(registry);
+
+        let results = handle.search("github issues sync").await.expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected mixed execution result");
+        assert_eq!(results[0].canonical_id, "github issues:sync");
+        assert_eq!(results[0].execution_type, "mcp");
+    }
+
+    #[tokio::test]
+    async fn search_with_vendor_matches_commands_when_catalog_identifier_is_stale() {
+        let render_projects = CommandSpec::new_http(
+            "projects".to_string(),
+            "list".to_string(),
+            "List Render projects.".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/v1/projects", None, None),
+            1,
+        );
+
+        let mut registry = CommandRegistry::default().with_commands(vec![render_projects.clone()]);
+        registry.config = RegistryConfig {
+            catalogs: Some(vec![build_catalog("Render", "render", vec![render_projects])]),
+        };
+
+        let handle = SearchHandle::new(Arc::new(Mutex::new(registry)));
+        let results = handle
+            .search_with_vendor("render projects", Some("render"))
+            .await
+            .expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected vendor-scoped search results");
+        assert_eq!(results[0].canonical_id, "projects list");
+    }
+
+    #[tokio::test]
+    async fn search_keeps_relevant_commands_ahead_of_noise() {
+        let registry = build_heterogeneous_registry();
+        let mut registry_guard = registry.lock().expect("registry lock");
+        for index in 0..40 {
+            registry_guard.commands.push(CommandSpec::new_http(
+                format!("misc{index}"),
+                "list".to_string(),
+                "Enumerate unrelated maintenance records.".to_string(),
+                Vec::new(),
+                Vec::new(),
+                HttpCommandSpec::new("GET", &format!("/v1/misc/{index}"), None, None),
+                0,
+            ));
+        }
+        drop(registry_guard);
+
+        let handle = SearchHandle::new(registry);
+        let results = handle.search("service scale").await.expect("search succeeds");
+
+        assert!(!results.is_empty(), "expected scaled service result");
+        assert_eq!(results[0].canonical_id, "services scale");
+    }
+
+    #[test]
+    fn normalize_identifier_splits_colon_and_slash_separators() {
+        assert_eq!(normalize_identifier("deployments:create/v1").as_ref(), "deployments create v1");
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1142,6 +1142,8 @@ pub mod messaging {
         pub execution_type: String,
         /// Optional HTTP method when the command is HTTP-backed.
         pub http_method: Option<String>,
+        /// Optional vendor associated with the resolved command.
+        pub vendor: Option<String>,
     }
 }
 


### PR DESCRIPTION
## Summary
- replace heuristic-heavy registry search ranking with a normalized  based pipeline
- share canonical-id vendor matching between registry and MCP search consumers
- cache the normalized search index inside  so repeated queries reuse precomputed search documents

## Validation
- cargo fmt --all
- cargo test -p oatty-registry
- cargo test -p oatty-mcp search_commands -- --nocapture