### PR TITLE
fix: preserve tokenized catalog headers in library and runtime execution

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -528,9 +528,8 @@ fn resolve_command_context(
         .resolve_base_url_for_command(&command_spec)
         .ok_or(anyhow!("base url not defined for this command"))?;
     let headers = registry_lock
-        .resolve_headers_for_command(&command_spec)
-        .ok_or(anyhow!("headers not defined for this command"))?
-        .clone();
+        .resolve_runtime_headers_for_command(&command_spec)
+        .ok_or(anyhow!("headers not defined for this command"))?;
     Ok((command_spec, base_url, headers))
 }
 

--- a/crates/engine/src/executor/runner.rs
+++ b/crates/engine/src/executor/runner.rs
@@ -217,7 +217,7 @@ impl CommandRunner for RegistryCommandRunner {
             .ok_or_else(|| anyhow!("base url not configured"))?;
         let headers = self
             .registry
-            .resolve_headers_for_command(&command_spec)
+            .resolve_runtime_headers_for_command(&command_spec)
             .ok_or_else(|| anyhow!("could not determine headers for command: {}", command_spec.canonical_id()))?;
         debug!(
             command = %command_spec.canonical_id(),
@@ -225,7 +225,7 @@ impl CommandRunner for RegistryCommandRunner {
             header_count = headers.len(),
             "resolved command HTTP settings"
         );
-        let client = OattyClient::new(base_url, headers).map_err(|error| anyhow!("could not create the HTTP client: {error}"))?;
+        let client = OattyClient::new(base_url, &headers).map_err(|error| anyhow!("could not create the HTTP client: {error}"))?;
 
         let mut input_map = extract_input_map(with);
         let path_variables = extract_path_variables(&command_spec, &mut input_map);

--- a/crates/engine/src/provider/registry.rs
+++ b/crates/engine/src/provider/registry.rs
@@ -105,9 +105,8 @@ fn fetch_and_cache(
             .resolve_base_url_for_command(&spec)
             .ok_or_else(|| anyhow!("missing base URL for command '{}'", spec.name))?;
         let headers = registry_lock
-            .resolve_headers_for_command(&spec)
-            .ok_or_else(|| anyhow!("could not determine headers for command: {}", &spec.canonical_id()))?
-            .clone();
+            .resolve_runtime_headers_for_command(&spec)
+            .ok_or_else(|| anyhow!("could not determine headers for command: {}", &spec.canonical_id()))?;
         debug!(
             provider_id = %provider_id,
             command = %spec.canonical_id(),

--- a/crates/mcp/src/server/core.rs
+++ b/crates/mcp/src/server/core.rs
@@ -1587,16 +1587,13 @@ async fn execute_http_command(
                 "Set a base URL for the catalog in Library, then retry the command.",
             )
         })?;
-        let headers = registry_guard
-            .resolve_headers_for_command(command_spec)
-            .ok_or_else(|| {
-                invalid_params_with_next_step(
-                    "headers not configured",
-                    serde_json::json!({ "canonical_id": command_spec.canonical_id() }),
-                    "Configure required headers for the catalog in Library, then retry the command.",
-                )
-            })?
-            .clone();
+        let headers = registry_guard.resolve_runtime_headers_for_command(command_spec).ok_or_else(|| {
+            invalid_params_with_next_step(
+                "headers not configured",
+                serde_json::json!({ "canonical_id": command_spec.canonical_id() }),
+                "Configure required headers for the catalog in Library, then retry the command.",
+            )
+        })?;
         (base_url, headers)
     };
 

--- a/crates/registry/src/config.rs
+++ b/crates/registry/src/config.rs
@@ -3,9 +3,8 @@ use std::{convert::Infallible, env, path::PathBuf};
 use anyhow::Error;
 use dirs_next::config_dir;
 use heck::{ToSnakeCase, ToSnekCase};
-use indexmap::set::MutableValues;
-use oatty_types::{EnvVar, manifest::RegistryCatalog};
-use oatty_util::{expand_tilde, interpolate_string, tokenize_env};
+use oatty_types::manifest::RegistryCatalog;
+use oatty_util::{expand_tilde, tokenize_env};
 use postcard::to_stdvec;
 use serde::{Deserialize, Serialize};
 
@@ -27,7 +26,9 @@ impl RegistryConfig {
 
     pub fn save(&mut self) -> Result<(), Error> {
         let path = default_config_path();
-        if let Some(catalogs) = self.catalogs.as_mut() {
+        let mut tokenized_config = self.clone();
+
+        if let Some(catalogs) = tokenized_config.catalogs.as_mut() {
             let catalogs_path = default_catalogs_path();
             std::fs::create_dir_all(&catalogs_path)?;
 
@@ -48,22 +49,9 @@ impl RegistryConfig {
             }
         }
 
-        let content = serde_json::to_string_pretty(self)?;
+        let content = serde_json::to_string_pretty(&tokenized_config)?;
         std::fs::write(&path, content)?;
 
-        if let Some(catalogs) = self.catalogs.as_mut() {
-            for catalog in catalogs {
-                for j in 0..catalog.headers.len() {
-                    let Some(EnvVar { value, .. }) = catalog.headers.get_index_mut2(j) else {
-                        continue;
-                    };
-                    let Ok(val) = interpolate_string(value) else {
-                        continue;
-                    };
-                    *value = val;
-                }
-            }
-        }
         Ok(())
     }
 }

--- a/crates/registry/src/models.rs
+++ b/crates/registry/src/models.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use indexmap::{IndexMap, IndexSet, set::MutableValues};
+use indexmap::{IndexMap, IndexSet};
 use oatty_types::{
     CommandSpec, EnvSource, EnvVar, ProviderContract,
     manifest::{RegistryCatalog, RegistryManifest},
@@ -199,16 +199,6 @@ impl CommandRegistry {
             for i in (0..catalogs.len()).rev() {
                 let catalog = &mut catalogs[i];
                 let path = &catalog.manifest_path;
-                for j in 0..catalog.headers.len() {
-                    let Some(EnvVar { value, .. }) = catalog.headers.get_index_mut2(j) else {
-                        continue;
-                    };
-                    let Ok(val) = interpolate_string(value) else {
-                        continue;
-                    };
-                    *value = val;
-                }
-
                 let Ok(manifest_bytes) = std::fs::read(path) else {
                     catalogs.swap_remove(i); // invalid - remove from registry
                     continue;
@@ -266,6 +256,28 @@ impl CommandRegistry {
         let catalog = self.get_catalog(catalog_identifier)?;
 
         Some(&catalog.headers)
+    }
+
+    /// Resolves request-ready headers for a command by interpolating any
+    /// `${env:...}` or `${secret:...}` placeholders at execution time.
+    ///
+    /// Returns `None` when the command is not associated with a catalog or when
+    /// any configured header value cannot be interpolated successfully.
+    pub fn resolve_runtime_headers_for_command(&self, command: &CommandSpec) -> Option<IndexSet<EnvVar>> {
+        let configured_headers = self.resolve_headers_for_command(command)?;
+        let mut runtime_headers = IndexSet::with_capacity(configured_headers.len());
+
+        for configured_header in configured_headers {
+            let interpolated_value = interpolate_string(&configured_header.value).ok()?;
+            runtime_headers.insert(EnvVar {
+                key: configured_header.key.clone(),
+                value: interpolated_value,
+                source: configured_header.source.clone(),
+                effective: configured_header.effective,
+            });
+        }
+
+        Some(runtime_headers)
     }
 
     /// Finds a specific command by its group and command name.
@@ -863,7 +875,7 @@ pub enum CommandRegistryEvent {
 mod tests {
     use super::*;
     use indexmap::IndexSet;
-    use oatty_types::manifest::RegistryCatalog;
+    use oatty_types::{command::HttpCommandSpec, manifest::RegistryCatalog};
 
     fn catalog_with_title(title: &str) -> RegistryCatalog {
         RegistryCatalog {
@@ -879,6 +891,18 @@ mod tests {
             manifest: Some(RegistryManifest::default()),
             is_enabled: true,
         }
+    }
+
+    fn command_with_catalog_identifier(catalog_identifier: usize) -> CommandSpec {
+        CommandSpec::new_http(
+            "catalog".to_string(),
+            "list".to_string(),
+            "List catalog items".to_string(),
+            Vec::new(),
+            Vec::new(),
+            HttpCommandSpec::new("GET", "/items", None, None),
+            catalog_identifier,
+        )
     }
 
     #[test]
@@ -947,6 +971,42 @@ mod tests {
         let header = headers.iter().next().expect("single header should exist");
         assert_eq!(header.key, "authorization");
         assert_eq!(header.value, "Bearer second");
+    }
+
+    #[test]
+    fn resolve_runtime_headers_interpolates_without_mutating_configured_values() {
+        let mut registry = CommandRegistry::default();
+        let mut catalog = catalog_with_title("alpha");
+        catalog.headers.insert(EnvVar {
+            key: "Authorization".to_string(),
+            value: "${env:OATTY_TEST_LIBRARY_HEADER}".to_string(),
+            source: EnvSource::Env,
+            effective: true,
+        });
+        registry.config.catalogs = Some(vec![catalog]);
+
+        let original_value = std::env::var("OATTY_TEST_LIBRARY_HEADER").ok();
+        unsafe { std::env::set_var("OATTY_TEST_LIBRARY_HEADER", "Bearer resolved") };
+
+        let command = command_with_catalog_identifier(0);
+
+        let configured_headers = registry
+            .resolve_headers_for_command(&command)
+            .expect("configured headers should exist");
+        let runtime_headers = registry
+            .resolve_runtime_headers_for_command(&command)
+            .expect("runtime headers should resolve");
+
+        let configured_header = configured_headers.iter().next().expect("configured header should exist");
+        let runtime_header = runtime_headers.iter().next().expect("runtime header should exist");
+
+        assert_eq!(configured_header.value, "${env:OATTY_TEST_LIBRARY_HEADER}");
+        assert_eq!(runtime_header.value, "Bearer resolved");
+
+        match original_value {
+            Some(value) => unsafe { std::env::set_var("OATTY_TEST_LIBRARY_HEADER", value) },
+            None => unsafe { std::env::remove_var("OATTY_TEST_LIBRARY_HEADER") },
+        }
     }
 
     #[test]

--- a/crates/tui/src/cmd.rs
+++ b/crates/tui/src/cmd.rs
@@ -1184,7 +1184,7 @@ fn spawn_execute_http(app: &mut App<'_>, spec: CommandSpec, input: String, reque
 
     if let Ok(lock) = app.ctx.command_registry.lock()
         && let Some(base_url) = lock.resolve_base_url_for_command(&spec)
-        && let Some(headers) = lock.resolve_headers_for_command(&spec).cloned()
+        && let Some(headers) = lock.resolve_runtime_headers_for_command(&spec)
     {
         return tokio::spawn(async move { execute_http_task(active, spec, input, base_url, &headers, request_id).await });
     }

--- a/crates/tui/src/ui/components/library/library_component.rs
+++ b/crates/tui/src/ui/components/library/library_component.rs
@@ -994,4 +994,10 @@ impl Component for LibraryComponent {
             outter[1],    // Error
         ]
     }
+
+    fn on_route_exit(&mut self, app: &mut App) -> Vec<Effect> {
+        let mut effect = self.track_lost_input_focus(app);
+        effect.append(&mut self.track_lost_kv_focus(app));
+        effect
+    }
 }

--- a/crates/tui/src/ui/components/library/state.rs
+++ b/crates/tui/src/ui/components/library/state.rs
@@ -184,11 +184,8 @@ impl LibraryState {
     }
 
     pub fn set_projections(&mut self, projections: Vec<CatalogProjection>) {
-        if self.api_selected_index().is_none() {
-            let idx = self.api_list_state.selected().unwrap_or(0).min(projections.len());
-            self.set_api_selected_index(Some(idx));
-        }
         self.projections = projections;
+        self.sync_selection_with_projections();
     }
 
     pub fn clear_projections(&mut self) {
@@ -198,6 +195,7 @@ impl LibraryState {
 
     pub fn push_projection(&mut self, projection: CatalogProjection) {
         self.projections.push(projection);
+        self.sync_selection_with_projections();
     }
 
     pub fn get_projection_mut(&mut self, idx: usize) -> Option<&mut CatalogProjection> {
@@ -311,6 +309,28 @@ impl LibraryState {
         self.projections.get_mut(index)
     }
 
+    /// Synchronizes the selected catalog index and all editor state after the
+    /// projections list changes.
+    fn sync_selection_with_projections(&mut self) {
+        if self.projections.is_empty() {
+            self.api_list_state.select(None);
+            self.description_input.clear();
+            self.base_url_input.clear();
+            self.update_kv_state();
+            return;
+        }
+
+        let selected_index = self
+            .api_list_state
+            .selected()
+            .unwrap_or(0)
+            .min(self.projections.len().saturating_sub(1));
+
+        self.api_list_state.select(Some(selected_index));
+        self.load_input_for_selected_api();
+        self.update_kv_state();
+    }
+
     fn update_kv_state(&mut self) {
         self.url_list_state.select(None);
         if let Some(p) = self.api_list_state.selected().and_then(|idx| self.projections.get(idx)) {
@@ -372,5 +392,42 @@ impl HasFocus for LibraryState {
 
     fn area(&self) -> Rect {
         Rect::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use indexmap::IndexSet;
+    use oatty_mcp::{EnvSource, EnvVar};
+
+    use super::LibraryState;
+    use crate::ui::components::library::CatalogProjection;
+
+    #[test]
+    fn set_projections_refreshes_header_editor_for_selected_catalog() {
+        let mut state = LibraryState::new();
+        state.set_projections(vec![catalog_projection("alpha", "Bearer old")]);
+        state.set_api_selected_index(Some(0));
+
+        state.set_projections(vec![catalog_projection("alpha", "Bearer new")]);
+
+        let rows = state.kv_state().rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "authorization");
+        assert_eq!(rows[0].value, "Bearer new");
+    }
+
+    fn catalog_projection(title: &str, header_value: &str) -> CatalogProjection {
+        let mut headers = IndexSet::new();
+        headers.insert(EnvVar::new("authorization".to_string(), header_value.to_string(), EnvSource::Raw));
+
+        CatalogProjection {
+            title: Cow::Owned(title.to_string()),
+            headers,
+            base_urls: vec!["https://example.com".to_string()],
+            ..Default::default()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- refresh the selected Library catalog editor state after projection updates so edited headers immediately show the saved value
- keep configured catalog headers tokenized in registry state and resolve them only at execution time
- write `registry.json` from a tokenized snapshot so resolved header values do not leak into persistence

## Testing
- `cargo fmt --all`
- `cargo test -p oatty-registry resolve_runtime_headers_interpolates_without_mutating_configured_values`
- `cargo test -p oatty-tui set_projections_refreshes_header_editor_for_selected_catalog`

Closes #70
